### PR TITLE
Add setup-node to GitHub actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.0
+          cache: "npm"
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,11 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.0
+          cache: "npm"
       - name: Run Lint
         run: |
           npm install 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,11 @@ jobs:
   jest-and-cypress-components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.0
+          cache: "npm"
       - name: Run Tests
         run: |
           npm install 

--- a/helpers/string.ts
+++ b/helpers/string.ts
@@ -15,11 +15,14 @@ export const formatDate = (d: Date | undefined): string => (d ? d.toLocaleDateSt
 
 export const formatTime = (d: Date | undefined): string =>
   d
-    ? d.toLocaleTimeString(undefined, {
-        hour12: true,
-        hour: 'numeric',
-        minute: '2-digit'
-      })
+    ? d
+        .toLocaleTimeString(undefined, {
+          hour12: true,
+          hour: 'numeric',
+          minute: '2-digit'
+        })
+        // ICU 72.1 may use different unicode space characters
+        .replace(/\u202f|\u2009/g, ' ')
     : '';
 
 export const checkPath = () => {


### PR DESCRIPTION
This PR specifies the Node version to use during GitHub actions and enables caching of the `node_modules` directory.