### PR TITLE
fixes conversationId issue creating empty conversations

### DIFF
--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -58,20 +58,20 @@ const RecipientControl = ({
 
   useEffect(() => {
     const setLookupValue = async () => {
+      const conversationIdOnXmtp =
+        conversationId?.replace(`${recipientWalletAddress}/`, "") ?? "";
       if (
         isValidLongWalletAddress(recipientWalletAddress) &&
         !conversations.get(recipientWalletAddress) &&
-        !conversations.get(conversationId ?? "")
+        !conversations.get(conversationIdOnXmtp)
       ) {
         const conversation =
-          conversationId && conversationId !== recipientWalletAddress
+          conversationIdOnXmtp &&
+          conversationIdOnXmtp !== recipientWalletAddress
             ? await client?.conversations?.newConversation(
                 recipientWalletAddress,
                 {
-                  conversationId: conversationId.replace(
-                    `${recipientWalletAddress}/`,
-                    "",
-                  ),
+                  conversationId: conversationIdOnXmtp,
                   metadata: {},
                 },
               )

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -63,7 +63,7 @@ const RecipientControl = ({
       if (
         isValidLongWalletAddress(recipientWalletAddress) &&
         !conversations.get(recipientWalletAddress) &&
-        !conversations.get(conversationIdOnXmtp)
+        !conversations.get(conversationId ?? "")
       ) {
         const conversation =
           conversationIdOnXmtp &&

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -64,7 +64,10 @@ const RecipientControl = ({
             ? await client?.conversations?.newConversation(
                 recipientWalletAddress,
                 {
-                  conversationId,
+                  conversationId: conversationId.replace(
+                    `${recipientWalletAddress}/`,
+                    "",
+                  ),
                   metadata: {},
                 },
               )

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -58,7 +58,11 @@ const RecipientControl = ({
 
   useEffect(() => {
     const setLookupValue = async () => {
-      if (isValidLongWalletAddress(recipientWalletAddress)) {
+      if (
+        isValidLongWalletAddress(recipientWalletAddress) &&
+        !conversations.get(recipientWalletAddress) &&
+        !conversations.get(conversationId ?? "")
+      ) {
         const conversation =
           conversationId && conversationId !== recipientWalletAddress
             ? await client?.conversations?.newConversation(


### PR DESCRIPTION
The issue was that the conversationId being passed from XMTP was not null but incorrect, creating a bunch of empty conversations.

The fix is to replace the address and pass the conversation id, but this begs the question do we need a standard for the conversation id and have a couple of checks on the server side that makes sure this is followed because it is highly possible that conversationId being passed incorrectly can happen again if not on our app maybe some other app.