### PR TITLE
Bring back cb.id support

### DIFF
--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -13,3 +13,5 @@ export const RecipientInputMode = {
 };
 
 export const CONVERSATION_CACHE_VERSION = 1;
+
+export const ALLOWED_ENS_SUFFIXES = [".eth", ".cb.id"];

--- a/helpers/string.ts
+++ b/helpers/string.ts
@@ -32,12 +32,7 @@ export const isEnsAddress = (address: string): boolean => {
     return false;
   }
 
-  for (const suffix of ALLOWED_ENS_SUFFIXES) {
-    if (address.endsWith(suffix)) {
-      return true;
-    }
-  }
-  return false;
+  return ALLOWED_ENS_SUFFIXES.some((suffix) => address.endsWith(suffix));
 };
 
 export const isValidRecipientAddressFormat = (

--- a/helpers/string.ts
+++ b/helpers/string.ts
@@ -1,4 +1,5 @@
 import { Conversation } from "@xmtp/xmtp-js";
+import { ALLOWED_ENS_SUFFIXES } from "./constants";
 
 export const truncate = (str: string | undefined, length: number): string => {
   if (!str) {
@@ -25,11 +26,25 @@ export const formatTime = (d: Date | undefined): string =>
         .replace(/\u202f|\u2009/g, " ")
     : "";
 
+export const isEnsAddress = (address: string): boolean => {
+  // Bail out early if empty string or a string without any dots
+  if (!address || !address.includes(".")) {
+    return false;
+  }
+
+  for (const suffix of ALLOWED_ENS_SUFFIXES) {
+    if (address.endsWith(suffix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const isValidRecipientAddressFormat = (
   recipientWalletAddress: string,
 ) => {
   return (
-    recipientWalletAddress?.endsWith(".eth") ||
+    isEnsAddress(recipientWalletAddress) ||
     (recipientWalletAddress?.startsWith("0x") &&
       recipientWalletAddress?.length === 42)
   );
@@ -40,10 +55,6 @@ export const isValidLongWalletAddress = (recipientWalletAddress: string) => {
     recipientWalletAddress?.startsWith("0x") &&
     recipientWalletAddress?.length === 42
   );
-};
-
-export const isEnsAddress = (address: string): boolean => {
-  return address.endsWith(".eth");
 };
 
 export const shortAddress = (addr: string): string =>

--- a/helpers/tests/string.test.ts
+++ b/helpers/tests/string.test.ts
@@ -70,6 +70,9 @@ describe("isEnsAddress", () => {
   it("should return false if invalid address", () => {
     expect(isEnsAddress("")).toBe(false);
   });
+  it("should return true for cb.id addresses", () => {
+    expect(isEnsAddress("test.cb.id")).toBe(true);
+  });
 
   describe("shortAddress", () => {
     it("should return properly formatted address with long addresses that start with 0x", () => {


### PR DESCRIPTION
## Summary

It appears that support for `.cb.id` addresses got lost in the move between `example-chat-react` and `inbox-web` (it's missing from the first commit in this repo).

Added support back in and includes a test to avoid future regressions.