### PR TITLE
updated date to be on one line, fixed input regression

### DIFF
--- a/component-library/components/DateDivider/DateDivider.tsx
+++ b/component-library/components/DateDivider/DateDivider.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 export const DateDivider = ({ date }: { date: Date }): JSX.Element => (
   <div className="flex align-items-center items-center pb-8 pt-4">
     <div className="grow h-0.5 bg-gray-300/25" />
-    <span className="mx-2 flex-none text-gray-500 text-sm font-bold">
+    <span className="mx-2 flex-none text-gray-500 text-xs font-bold">
       {format(date, "PPP")}
     </span>
     <div className="grow h-0.5 bg-gray-300/25" />

--- a/component-library/components/FullConversation/FullConversation.tsx
+++ b/component-library/components/FullConversation/FullConversation.tsx
@@ -31,7 +31,7 @@ export const FullConversation = ({
       className="w-full h-full flex flex-col-reverse pt-8 px-4 md:px-8">
       {messages}
       <div
-        className="text-gray-400 font-regular text-sm w-full py-2 text-center"
+        className="text-gray-500 font-regular text-sm w-full py-2 text-center"
         data-testid="message-beginning-text">
         {t("messages.conversation_start")}
       </div>

--- a/component-library/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/component-library/components/HeaderDropdown/HeaderDropdown.tsx
@@ -55,7 +55,7 @@ export const HeaderDropdown = ({
         </span>
         <IconButton
           onClick={() => onClick?.()}
-          label={<PlusIcon color="white" width="16" />}
+          label={<PlusIcon color="white" width="20" />}
           testId="new-message-icon-cta"
           srText={t("aria_labels.start_new_message") || ""}
         />

--- a/component-library/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/component-library/components/HeaderDropdown/HeaderDropdown.tsx
@@ -47,7 +47,7 @@ export const HeaderDropdown = ({
     <div
       data-modal-target="headerModalId"
       data-testId="conversation-list-header"
-      className="border-l border-r border-b border-gray-200 bg-gray-100 h-16 p-4 pl-20">
+      className="border-l border-r border-b border-gray-200 bg-gray-100 h-16 p-4 pl-20 pt-5">
       <div className="flex justify-between items-center">
         <span className="flex" onClick={() => setIsOpen(!isOpen)}>
           <h1 className="font-bold text-lg mr-2">{currentlySelected}</h1>

--- a/component-library/components/IconButton/IconButton.tsx
+++ b/component-library/components/IconButton/IconButton.tsx
@@ -95,7 +95,7 @@ export const IconButton = ({
           className={classNames(
             "bg-indigo-600",
             "hover:bg-indigo-800",
-            size === "small" ? "p-1 min-h-20" : "p-2 min-h-24",
+            size === "small" ? "p-1 min-h-20" : "p-1 min-h-24",
             shape,
           )}>
           {isLoading ? <ButtonLoader color={"primary"} size={size} /> : label}

--- a/component-library/components/IconButton/IconButton.tsx
+++ b/component-library/components/IconButton/IconButton.tsx
@@ -95,7 +95,7 @@ export const IconButton = ({
           className={classNames(
             "bg-indigo-600",
             "hover:bg-indigo-800",
-            size === "small" ? "p-1 min-h-20" : "p-1 min-h-24",
+            size === "small" ? "p-1 min-h-20" : "p-2 min-h-24",
             shape,
           )}>
           {isLoading ? <ButtonLoader color={"primary"} size={size} /> : label}

--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -22,7 +22,7 @@ export const MessageInput = ({ onSubmit, isDisabled }: InputProps) => {
   const onChange = (event: ChangeEvent<HTMLTextAreaElement>) =>
     setValue(event.target.value);
   const borderStyles =
-    "border border-gray-300 focus-within:border-1 focus-within:border-indigo-600 rounded-tl-2xl rounded-bl-2xl rounded-tr-2xl";
+    "border border-gray-300 focus-within:border-1 focus-within:border-indigo-600 rounded-tl-3xl rounded-bl-3xl rounded-tr-3xl";
   const textAreaStyles = `${
     textAreaRef?.current?.scrollHeight &&
     textAreaRef?.current?.scrollHeight <= 32
@@ -85,7 +85,7 @@ export const MessageInput = ({ onSubmit, isDisabled }: InputProps) => {
           <IconButton
             testId="message-input-submit"
             variant="secondary"
-            label={<ArrowUpIcon color="white" width="12" />}
+            label={<ArrowUpIcon color="white" width="20" />}
             srText={t("aria_labels.submit_message") || ""}
             onClick={() => {
               if (value) {

--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -22,7 +22,7 @@ export const MessageInput = ({ onSubmit, isDisabled }: InputProps) => {
   const onChange = (event: ChangeEvent<HTMLTextAreaElement>) =>
     setValue(event.target.value);
   const borderStyles =
-    "border border-gray-300 focus-within:border-1 focus-within:border-indigo-600 rounded-tl-full rounded-bl-full rounded-tr-full";
+    "border border-gray-300 focus-within:border-1 focus-within:border-indigo-600 rounded-tl-2xl rounded-bl-2xl rounded-tr-2xl";
   const textAreaStyles = `${
     textAreaRef?.current?.scrollHeight &&
     textAreaRef?.current?.scrollHeight <= 32

--- a/component-library/components/MessagePreviewCard/MessagePreviewCard.tsx
+++ b/component-library/components/MessagePreviewCard/MessagePreviewCard.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import { IconSkeletonLoader } from "../Loaders/SkeletonLoaders/IconSkeletonLoader";
 import { ShortCopySkeletonLoader } from "../Loaders/SkeletonLoaders/ShortCopySkeletonLoader";
 
-import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import { classNames } from "../../../helpers";
 import { Avatar } from "../Avatar/Avatar";
 import { useTranslation } from "react-i18next";
+import { formatDistanceToNowStrict } from "date-fns";
 
 interface MessagePreviewCard {
   /**
@@ -98,7 +98,7 @@ export const MessagePreviewCard = ({
         {isLoading ? (
           <ShortCopySkeletonLoader />
         ) : (
-          <span className="text-md text-gray-600 line-clamp-1 max-w-[90%] break-all">
+          <span className="text-md text-gray-600 line-clamp-1 w-full break-all">
             {text ?? t("messages.convos_empty_text_placeholder")}
           </span>
         )}
@@ -110,14 +110,14 @@ export const MessagePreviewCard = ({
           className={classNames(
             "text-xs",
             "text-gray-600",
-            "w-1/4",
+            "w-1/3",
             "text-right",
             "ml-4",
             "h-full",
           )}>
           {datetime &&
             t("messages.time_since_message", {
-              TIME: formatDistanceToNow(datetime),
+              TIME: formatDistanceToNowStrict(datetime),
             })}
         </div>
       )}

--- a/component-library/components/SideNav/SideNav.tsx
+++ b/component-library/components/SideNav/SideNav.tsx
@@ -128,7 +128,7 @@ const SideNav = ({
   return (
     <div
       className={classNames(
-        "flex flex-col justify-between items-center h-screen bg-gray-50 px-3 absolute z-10",
+        "flex flex-col justify-between items-center h-screen bg-gray-50 px-3 absolute z-10 border-r border-gray-200",
       )}>
       <div className="flex flex-col items-start space-y-4 w-full">
         <div className="py-4 flex">


### PR DESCRIPTION
**Design updates include:**
* Added border to side nav 
* Updated timestamp to only be on one line while still respecting max-w-md of the larger container
* Updated text to meet color-contrast requirement
* Fixed message input regression when entering large blocks of text
