### PR TITLE
Specify env in canMessage call

### DIFF
--- a/hooks/useInitXmtpClient.ts
+++ b/hooks/useInitXmtpClient.ts
@@ -75,7 +75,7 @@ const useInitXmtpClient = () => {
       const address = await signer.getAddress();
       try {
         setIsLoading(true);
-        const canMessage = await Client.canMessage(address);
+        const canMessage = await Client.canMessage(address, { env: getEnv() });
         if (canMessage) {
           setNewAccount(false);
           connectToXmtp();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@heroicons/react": "^1.0.5",
         "@rainbow-me/rainbowkit": "^0.8.1",
         "@tailwindcss/line-clamp": "^0.4.2",
-        "@xmtp/xmtp-js": "^8.0.0-beta.13",
+        "@xmtp/xmtp-js": "^8.0.0-beta.14",
         "date-fns": "^2.29.3",
         "ethers": "^5.7.2",
         "i18next": "^22.4.13",
@@ -14225,9 +14225,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.22.9",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.22.9.tgz",
-      "integrity": "sha512-f7vcCBuU68znENrrvo7XMHW1T0xnvCyWJPMMsYnaLL10840qptIKTikuY83l04UI5Q0sZ4ARHdJga0z37ti/mA==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -14236,13 +14236,13 @@
       }
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "8.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.13.tgz",
-      "integrity": "sha512-uLFQY7E+qM8bznclrq1qhPiNPWyeV6xYyN9YPdwoJ7re/FB17RXUTgTz/chyDey9d70RUAA81itkX/NF1IH+7Q==",
+      "version": "8.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.14.tgz",
+      "integrity": "sha512-acfURBsb3m+1HyJqLZbFRYfyc7L0+ouPhICbAWNxlPHW3qSHv0FZnvpfQIu/m/oUa96e67wNIDlWZzOxuKsIAw==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.22.0-beta.1",
+        "@xmtp/proto": "^3.24.0-beta.2",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -49137,9 +49137,9 @@
       }
     },
     "@xmtp/proto": {
-      "version": "3.22.9",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.22.9.tgz",
-      "integrity": "sha512-f7vcCBuU68znENrrvo7XMHW1T0xnvCyWJPMMsYnaLL10840qptIKTikuY83l04UI5Q0sZ4ARHdJga0z37ti/mA==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -49148,13 +49148,13 @@
       }
     },
     "@xmtp/xmtp-js": {
-      "version": "8.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.13.tgz",
-      "integrity": "sha512-uLFQY7E+qM8bznclrq1qhPiNPWyeV6xYyN9YPdwoJ7re/FB17RXUTgTz/chyDey9d70RUAA81itkX/NF1IH+7Q==",
+      "version": "8.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.14.tgz",
+      "integrity": "sha512-acfURBsb3m+1HyJqLZbFRYfyc7L0+ouPhICbAWNxlPHW3qSHv0FZnvpfQIu/m/oUa96e67wNIDlWZzOxuKsIAw==",
       "requires": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.22.0-beta.1",
+        "@xmtp/proto": "^3.24.0-beta.2",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@heroicons/react": "^1.0.5",
     "@rainbow-me/rainbowkit": "^0.8.1",
     "@tailwindcss/line-clamp": "^0.4.2",
-    "@xmtp/xmtp-js": "^8.0.0-beta.13",
+    "@xmtp/xmtp-js": "^8.0.0-beta.14",
     "date-fns": "^2.29.3",
     "ethers": "^5.7.2",
     "i18next": "^22.4.13",


### PR DESCRIPTION
## Summary

I was looking into the issue with Smurf Society, and noticed this in the console logs from prod. This should resolve the issue.


<img width="538" alt="CleanShot 2023-03-31 at 17 28 23@2x" src="https://user-images.githubusercontent.com/65710/229256654-8b2f0609-ab0b-4fa5-86dc-74f422e35050.png">
