### PR TITLE
Updated mobile styling tweaks and added background for address input

### DIFF
--- a/component-library/components/AddressInput/AddressInput.tsx
+++ b/component-library/components/AddressInput/AddressInput.tsx
@@ -61,9 +61,9 @@ export const AddressInput = ({
   value,
 }: AddressInputProps) => {
   const { t } = useTranslation();
-  const subtextColor = isError ? "text-red-600" : "text-gray-400";
+  const subtextColor = isError ? "text-red-600" : "text-gray-500";
   return (
-    <div className="flex px-2 md:px-4 py-3 border-b border-gray-100 border-l-0 z-10 max-h-sm w-full h-16">
+    <div className="bg-indigo-50 flex px-2 md:px-4 py-3 border-b border-indigo-500 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16">
       <form
         className="flex w-full items-center"
         onSubmit={(e) => e.preventDefault()}>
@@ -89,7 +89,7 @@ export const AddressInput = ({
             <input
               data-testid="message-to-input"
               tabIndex={0}
-              className="text-gray-700 px-0 h-4 m-1 ml-0 font-mono text-sm w-full leading-tight border-none focus:ring-0 cursor-text"
+              className="bg-transparent text-gray-900 px-0 h-4 m-1 ml-0 font-mono max-md:text-[16px] md:text-sm w-full leading-tight border-none focus:ring-0 cursor-text"
               id="address"
               type="search"
               spellCheck="false"

--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -28,7 +28,7 @@ export const MessageInput = ({ onSubmit, isDisabled }: InputProps) => {
     textAreaRef?.current?.scrollHeight <= 32
       ? "max-h-8"
       : "max-h-40"
-  } min-h-8 outline-none border-none focus:ring-0 resize-none mx-2 p-1 w-full text-md text-gray-900`;
+  } min-h-8 outline-none border-none focus:ring-0 resize-none mx-2 p-1 w-full max-md:text-[16px] md:text-md text-gray-900`;
 
   useLayoutEffect(() => {
     const MIN_TEXTAREA_HEIGHT = 32;

--- a/component-library/components/OnboardingStep/OnboardingStep.tsx
+++ b/component-library/components/OnboardingStep/OnboardingStep.tsx
@@ -52,7 +52,7 @@ export const OnboardingStep = ({
     const { header, subheader, cta, subtext, disconnect_tip } = stepInfo;
 
     return (
-      <div className="bg-white flex flex-col justify-center items-center max-w-sm text-center m-auto w-screen p-4 h-screen">
+      <div className="bg-white flex flex-col justify-around items-center max-w-sm text-center m-auto w-screen p-4 h-screen">
         {isLoading ? (
           <Spinner />
         ) : (

--- a/pages/inbox.tsx
+++ b/pages/inbox.tsx
@@ -140,6 +140,7 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
                       setRecipientInputMode(RecipientInputMode.InvalidEntry);
                     }}
                     width={32}
+                    className="bg-indigo-50 border-b border-indigo-500"
                   />
                 ) : null}
                 <AddressInputWrapper />


### PR DESCRIPTION
Adds some mobile styling tweaks:

- On iOS, font sizes below 16px trigger an auto-zoom, so set to 16px for mobile views only
- Fixes overlapping loader regression in mobile views

Updates address input to show purple background (all views, not just mobile), and adjusts some colors accordingly:
<img width="300"  alt="Screenshot 2023-04-03 at 2 33 47 PM" src="https://user-images.githubusercontent.com/35409260/229634646-30feb08d-14f5-4576-b673-b8c27ef7ee6f.png">
