### PR TITLE
updated arrow to be within proper input element

### DIFF
--- a/component-library/components/AddressInput/AddressInput.tsx
+++ b/component-library/components/AddressInput/AddressInput.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { Avatar } from "../Avatar/Avatar";
-import { InformationCircleIcon } from "@heroicons/react/outline";
+import {
+  ChevronLeftIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/outline";
 import { classNames } from "../../../helpers";
 import { ShortCopySkeletonLoader } from "../Loaders/SkeletonLoaders/ShortCopySkeletonLoader";
 import { useTranslation } from "react-i18next";
@@ -48,6 +51,10 @@ interface AddressInputProps {
    * Input Value
    */
   value?: string;
+  /**
+   * Is there a left icon click event that needs to be handled?
+   */
+  onLeftIconClick?: () => void;
 }
 
 export const AddressInput = ({
@@ -59,11 +66,15 @@ export const AddressInput = ({
   isLoading,
   onTooltipClick,
   value,
+  onLeftIconClick,
 }: AddressInputProps) => {
   const { t } = useTranslation();
   const subtextColor = isError ? "text-red-600" : "text-gray-500";
   return (
     <div className="bg-indigo-50 flex px-2 md:px-4 py-3 border-b border-indigo-500 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16">
+      <div className="max-md:w-fit md:hidden flex w-24 p-0 justify-start">
+        <ChevronLeftIcon onClick={onLeftIconClick} width={24} />
+      </div>
       <form
         className="flex w-full items-center"
         onSubmit={(e) => e.preventDefault()}>
@@ -80,7 +91,7 @@ export const AddressInput = ({
                 {resolvedAddress.displayAddress}
               </span>
               {resolvedAddress.walletAddress && (
-                <span className="text-sm font-mono">
+                <span className="text-sm max-md:text-xs font-mono">
                   {resolvedAddress.walletAddress}
                 </span>
               )}

--- a/pages/inbox.tsx
+++ b/pages/inbox.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect } from "react";
 import useListConversations from "../hooks/useListConversations";
 import { useXmtpStore } from "../store/xmtp";
-import {
-  getConversationId,
-  RecipientInputMode,
-  TAILWIND_MD_BREAKPOINT,
-} from "../helpers";
+import { getConversationId, TAILWIND_MD_BREAKPOINT } from "../helpers";
 import { ConversationList } from "../component-library/components/ConversationList/ConversationList";
 import { Conversation } from "@xmtp/xmtp-js";
 import { MessagePreviewCardWrapper } from "../wrappers/MessagePreviewCardWrapper";
@@ -18,7 +14,6 @@ import useInitXmtpClient from "../hooks/useInitXmtpClient";
 import { LearnMore } from "../component-library/components/LearnMore/LearnMore";
 import router from "next/router";
 import useWindowSize from "../hooks/useWindowSize";
-import { ChevronLeftIcon } from "@heroicons/react/solid";
 import useHandleConnect from "../hooks/useHandleConnect";
 
 export type address = "0x${string}";
@@ -34,24 +29,11 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
     (state) => state.recipientWalletAddress,
   );
 
-  const setRecipientWalletAddress = useXmtpStore(
-    (state) => state.setRecipientWalletAddress,
-  );
-
-  const setConversationId = useXmtpStore((state) => state.setConversationId);
-
   const size = useWindowSize();
 
   const previewMessages = useXmtpStore((state) => state.previewMessages);
   const recipientEnteredValue = useXmtpStore(
     (state) => state.recipientEnteredValue,
-  );
-  const setRecipientEnteredValue = useXmtpStore(
-    (state) => state.setRecipientEnteredValue,
-  );
-
-  const setRecipientInputMode = useXmtpStore(
-    (state) => state.setRecipientInputMode,
   );
 
   const loadingConversations = useXmtpStore(
@@ -130,19 +112,6 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
           ) : (
             <>
               <div className="flex">
-                {size[0] <= TAILWIND_MD_BREAKPOINT ? (
-                  <ChevronLeftIcon
-                    onClick={() => {
-                      setRecipientEnteredValue("");
-                      setRecipientWalletAddress("");
-                      setStartedFirstMessage(false);
-                      setConversationId("");
-                      setRecipientInputMode(RecipientInputMode.InvalidEntry);
-                    }}
-                    width={32}
-                    className="bg-indigo-50 border-b border-indigo-500"
-                  />
-                ) : null}
                 <AddressInputWrapper />
               </div>
               <div className="h-full overflow-auto flex flex-col">

--- a/wrappers/AddressInputWrapper.tsx
+++ b/wrappers/AddressInputWrapper.tsx
@@ -20,6 +20,16 @@ export const AddressInputWrapper = () => {
   const loadingConversations = useXmtpStore(
     (state) => state.loadingConversations,
   );
+  const setRecipientWalletAddress = useXmtpStore(
+    (state) => state.setRecipientWalletAddress,
+  );
+  const setStartedFirstMessage = useXmtpStore(
+    (state) => state.setStartedFirstMessage,
+  );
+  const setConversationId = useXmtpStore((state) => state.setConversationId);
+  const setRecipientInputMode = useXmtpStore(
+    (state) => state.setRecipientInputMode,
+  );
 
   // XMTP Hooks
   const {
@@ -63,6 +73,13 @@ export const AddressInputWrapper = () => {
         url: recipientAvatarUrl || "",
         isLoading: avatarLoading || loadingConversations,
         address: recipientWalletAddress,
+      }}
+      onLeftIconClick={() => {
+        setRecipientEnteredValue("");
+        setRecipientWalletAddress("");
+        setStartedFirstMessage(false);
+        setConversationId("");
+        setRecipientInputMode(RecipientInputMode.InvalidEntry);
       }}
     />
   );


### PR DESCRIPTION
Arrow on mobile was being handled outside of the address input element, creating some undesired views now that we've  added in the border and the background to input. 

This PR moves it to the address input element where it should be.