### PR TITLE
Fixed border hiding text color

### DIFF
--- a/component-library/components/AddressInput/AddressInput.tsx
+++ b/component-library/components/AddressInput/AddressInput.tsx
@@ -71,7 +71,7 @@ export const AddressInput = ({
   const { t } = useTranslation();
   const subtextColor = isError ? "text-red-600" : "text-gray-500";
   return (
-    <div className="bg-indigo-50 flex px-2 md:px-4 py-3 border-b border-indigo-500 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16">
+    <div className="bg-indigo-50 flex items-center px-2 md:px-4 py-3 border-b border-indigo-500 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16">
       <div className="max-md:w-fit md:hidden flex w-24 p-0 justify-start">
         <ChevronLeftIcon onClick={onLeftIconClick} width={24} />
       </div>
@@ -100,7 +100,7 @@ export const AddressInput = ({
             <input
               data-testid="message-to-input"
               tabIndex={0}
-              className="bg-transparent text-gray-900 px-0 h-4 m-1 ml-0 font-mono max-md:text-[16px] md:text-sm w-full leading-tight border-none focus:ring-0 cursor-text"
+              className="bg-transparent text-gray-900 px-0 h-4 m-1 ml-0 font-mono max-md:text-[16px] md:text-sm w-full leading-tight border border-2 border-transparent focus:border-transparent focus:ring-0 cursor-text"
               id="address"
               type="search"
               spellCheck="false"


### PR DESCRIPTION
For some reason, on some mobile browsers the hidden border of the address input element. was also hiding the text in its container. This PR adds back the border with a transparent background, so it still functions as expected.