### PR TITLE
Support apiUrl from env and add auto-published dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.next
+node_modules
+out

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,19 @@
+name: Publish Docker
+on:
+  push:
+    branches:
+      - main
+env:
+  BUILD_CONTAINER_IMAGE: xmtplabs/xmtp-inbox-web:latest
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: docker/build
+      - run: docker/push

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+# Install dependencies only when needed
+FROM node:alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:alpine AS builder
+WORKDIR /app
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+ENV NEXT_PUBLIC_XMTP_API_URL=PLACEHOLDER_XMTP_API_URL
+RUN npm run build && npm install --production --ignore-scripts --prefer-offline
+
+# Production image, copy all the files and run next
+FROM node:alpine AS runner
+WORKDIR /app
+
+RUN apk update && \
+    apk add bash
+
+ENV NODE_ENV production
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+# COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 3000
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry.
+ENV NEXT_TELEMETRY_DISABLED 1
+
+COPY docker/entrypoint.sh /opt/entrypoint.sh
+
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
+CMD ["/opt/entrypoint.sh"]

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+set -a; source "${script_dir}/.env.default"; set +a
+
+docker build \
+    --tag "${BUILD_CONTAINER_IMAGE}" \
+    -f "${script_dir}/Dockerfile" \
+    .

--- a/docker/buildx
+++ b/docker/buildx
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+set -a; source "${script_dir}/.env.default"; set +a
+
+docker buildx build \
+    --platform linux/amd64 \
+    --tag "${BUILD_CONTAINER_IMAGE}" \
+    -f "${script_dir}/Dockerfile" \
+    .

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+PORT="${PORT:-3000}"
+XMTP_API_URL="${XMTP_API_URL:-http://localhost}"
+find .next -type f -print0 | xargs -0 sed -i -e "s|PLACEHOLDER_XMTP_API_URL|${XMTP_API_URL}|g"
+npm run start -- -p "${PORT}"

--- a/docker/push
+++ b/docker/push
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+set -a; source "${script_dir}/.env.default"; set +a
+
+docker push "${BUILD_CONTAINER_IMAGE}"

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+set -a; source "${script_dir}/.env.default"; set +a
+
+docker run --rm -it -p "3000:3000" "${BUILD_CONTAINER_IMAGE}"

--- a/hooks/useInitXmtpClient.ts
+++ b/hooks/useInitXmtpClient.ts
@@ -27,6 +27,7 @@ const useInitXmtpClient = () => {
         let keys = loadKeys(address);
         if (!keys) {
           keys = await Client.getKeys(signer, {
+            apiUrl: process.env.NEXT_PUBLIC_XMTP_API_URL,
             env: getEnv(),
             appVersion: getAppVersion(),
           });
@@ -56,6 +57,7 @@ const useInitXmtpClient = () => {
         let keys = loadKeys(address);
         if (!keys) {
           keys = await Client.getKeys(signer, {
+            apiUrl: process.env.NEXT_PUBLIC_XMTP_API_URL,
             env: getEnv(),
             appVersion: getAppVersion(),
             // We don't need to publish the contact here since it
@@ -68,6 +70,7 @@ const useInitXmtpClient = () => {
           storeKeys(address, keys);
         }
         const xmtp = await Client.create(null, {
+          apiUrl: process.env.NEXT_PUBLIC_XMTP_API_URL,
           env: getEnv(),
           appVersion: getAppVersion(),
           persistConversations: true,
@@ -91,7 +94,10 @@ const useInitXmtpClient = () => {
       try {
         setIsLoading(true);
         setIsRequestPending(true);
-        const canMessage = await Client.canMessage(address, { env: getEnv() });
+        const canMessage = await Client.canMessage(address, {
+          apiUrl: process.env.NEXT_PUBLIC_XMTP_API_URL,
+          env: getEnv(),
+        });
         if (canMessage) {
           setNewAccount(false);
           connectToXmtp();


### PR DESCRIPTION
This PR adds support for passing the `NEXT_PUBLIC_XMTP_API_URL` env variable during build, adds a `Dockerfile` and some build scripts for it in `docker/`, and a GH workflow for auto building+publishing the container image. This is not intended for production builds, where we would just want to publish the static build via something like Vercel. The purpose of the container image is to allow for lightweight devnet/testnet deployments without requiring a new nextjs build for each. I tried to keep it all out of the way and in the `docker/` dir 😅 