### PR TITLE
build: add missing docker/.env.default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ build/
 
 # Environment
 .env*
+!docker/.env.default

--- a/docker/.env.default
+++ b/docker/.env.default
@@ -1,0 +1,1 @@
+BUILD_CONTAINER_IMAGE="${BUILD_CONTAINER_IMAGE:-xmtpdev/xmtp-inbox-web:dev}"


### PR DESCRIPTION
This PR fixes this broken GH docker build/publish workflow: https://github.com/xmtp-labs/xmtp-inbox-web/actions/runs/4723655940/jobs/8379892640