### PR TITLE
Include infura id during docker build

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
 assignees: bhavya2611
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement
 assignees: bhavya2611
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dev
 env:
   BUILD_CONTAINER_IMAGE: xmtplabs/xmtp-inbox-web:latest
 jobs:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,4 +16,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - uses: actions/checkout@v3
       - run: docker/build
+        env:
+          NEXT_PUBLIC_INFURA_ID: ${{ secrets.NEXT_PUBLIC_INFURA_ID }}
       - run: docker/push


### PR DESCRIPTION
We started seeing these ethersproject 401 errors when the container starts up, and we can see in the [build logs](https://github.com/xmtp-labs/xmtp-inbox-web/actions/runs/4758345809/jobs/8511577546) that it's showing the same thing. 

```
node:events:489
      throw er; // Unhandled 'error' event
      ^

Error: Unexpected server response: 401
    at ClientRequest.<anonymous> (/app/node_modules/@ethersproject/providers/node_modules/ws/lib/websocket.js:604:7)
    at ClientRequest.emit (node:events:511:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:693:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
    at TLSSocket.socketOnData (node:_http_client:535:22)
    at TLSSocket.emit (node:events:511:28)
    at addChunk (node:internal/streams/readable:332:12)
    at readableAddChunk (node:internal/streams/readable:305:9)
    at Readable.push (node:internal/streams/readable:242:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23)
Emitted 'error' event on WebSocket instance at:
    at abortHandshake (/app/node_modules/@ethersproject/providers/node_modules/ws/lib/websocket.js:731:15)
    at ClientRequest.<anonymous> (/app/node_modules/@ethersproject/providers/node_modules/ws/lib/websocket.js:604:7)
    [... lines matching original stack trace ...]
    at Readable.push (node:internal/streams/readable:242:10)
```

This PR fixes the issue by including the `NEXT_PUBLIC_INFURA_ID` env variable in the GH workflow.