### PR TITLE
Enable dm route

### DIFF
--- a/pages/dm/[...recipientWalletAddr].tsx
+++ b/pages/dm/[...recipientWalletAddr].tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { isEnsAddress, isValidRecipientAddressFormat } from "../../helpers";
+import { useXmtpStore } from "../../store/xmtp";
+import { fetchEnsAddress } from "@wagmi/core";
+
+const DmPage: NextPage = () => {
+  const router = useRouter();
+  const setConversationId = useXmtpStore((state) => state.setConversationId);
+  const setRecipientWalletAddress = useXmtpStore(
+    (state) => state.setRecipientWalletAddress,
+  );
+
+  useEffect(() => {
+    const routeToInbox = async () => {
+      let recipient = window.location.pathname.split("/")[2];
+      if (isValidRecipientAddressFormat(recipient)) {
+        if (isEnsAddress(recipient)) {
+          recipient =
+            (await fetchEnsAddress({
+              name: recipient,
+            })) ?? "";
+        }
+        setConversationId(recipient);
+        setRecipientWalletAddress(recipient);
+        router.push("/inbox");
+      }
+    };
+    if (window.location.pathname.includes("/dm")) {
+      routeToInbox();
+    }
+  }, [window.location.pathname]);
+
+  return <div></div>;
+};
+
+export default DmPage;

--- a/pages/dm/[...recipientWalletAddr].tsx
+++ b/pages/dm/[...recipientWalletAddr].tsx
@@ -14,7 +14,7 @@ const DmPage: NextPage = () => {
 
   useEffect(() => {
     const routeToInbox = async () => {
-      let recipient = window.location.pathname.split("/")[2];
+      let recipient = window.location.pathname.split("/").slice(-1)[0];
       if (isValidRecipientAddressFormat(recipient)) {
         if (isEnsAddress(recipient)) {
           recipient =

--- a/pages/dm/index.tsx
+++ b/pages/dm/index.tsx
@@ -6,7 +6,7 @@ const Conversation: NextPage = () => {
   const router = useRouter();
 
   useEffect(() => {
-    let recipient = window.location.pathname.split("/")[2];
+    let recipient = window.location.pathname.split("/").slice(-1)[0];
     if (!recipient) {
       router.push("/");
     }

--- a/pages/dm/index.tsx
+++ b/pages/dm/index.tsx
@@ -1,0 +1,7 @@
+import { NextPage } from "next";
+
+const Conversation: NextPage = () => {
+  return <div />;
+};
+
+export default Conversation;

--- a/pages/dm/index.tsx
+++ b/pages/dm/index.tsx
@@ -1,6 +1,16 @@
 import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 const Conversation: NextPage = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    let recipient = window.location.pathname.split("/")[2];
+    if (!recipient) {
+      router.push("/");
+    }
+  }, [window.location.pathname]);
   return <div />;
 };
 


### PR DESCRIPTION
Fixes #183 

This is only to enable dm route, so now once we have a share qr option, people can, for example, click on xmtp.chat/dm/montez.eth and be navigated to a conversation with montez, or start a conversation with him, we still won't have routes because that is causing other issues, the only route will be inbox.

CC - @snormore @eleanorhofstedt @petermdenton @yash-luna 