### PR TITLE
Remove SDK Styling

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
-import "@xmtp/react-sdk/style.css";
+// Temporarily removing until we pull components from the SDK.
+// import "@xmtp/react-sdk/style.css";
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import dynamic from "next/dynamic";


### PR DESCRIPTION
SDK stylesheet was pulled in which included some letter spacing styling we don't need in our app. Since we're only consuming the hooks from the SDK for now, commenting this out to close #221 and not risk design regressions from styles we're not yet using. 

Separately, updated the letter spacing issue directly to SDK here: https://github.com/xmtp/xmtp-web/pull/28