### PR TITLE
Updated disconnect callback on onboarding page

### DIFF
--- a/component-library/components/FullMessage/FullMessage.tsx
+++ b/component-library/components/FullMessage/FullMessage.tsx
@@ -61,8 +61,7 @@ export const FullMessage = ({
               isOutgoingMessage
                 ? outgoingMessageBackgroundStyles
                 : incomingMessageBackgroundStyles
-            }`}
-            data-testid="message-tile-text">
+            }`}>
             {text}
           </div>
           <div

--- a/cypress/e2e/messaging.cy.ts
+++ b/cypress/e2e/messaging.cy.ts
@@ -19,10 +19,6 @@ describe(
       startDemoEnv();
       // In connected flow, empty message should render before any tests run
       checkElement("empty-message-header");
-      checkElement("empty-message-cta");
-      // Need to break up the click chain for GitHub actions
-
-      cy.get(`[data-testid=empty-message-cta]`).click({ timeout: TIMEOUT });
     });
     const testUserWithXmtpAccount =
       "0x78BfD39428C32Be149892d64bEE6C6f90aedEec1";
@@ -57,7 +53,9 @@ describe(
     });
 
     it("Renders error message when sending message to existing user outside of XMTP network", () => {
-      checkElement("message-to-input").type("invalidUser").click();
+      checkElement("empty-message-cta");
+      cy.get(`[data-testid=empty-message-cta]`).click();
+      checkElement("message-to-input").type("invalidUser");
       cy.get(`[data-testid=message-to-subtext]`, { timeout: TIMEOUT }).should(
         "have.text",
         "Please enter a valid 0x wallet or ENS address",

--- a/cypress/e2e/messaging.cy.ts
+++ b/cypress/e2e/messaging.cy.ts
@@ -22,7 +22,7 @@ describe(
       checkElement("empty-message-cta");
       // Need to break up the click chain for GitHub actions
 
-      cy.get(`[data-testid=message-section-link]`).click({ timeout: TIMEOUT });
+      cy.get(`[data-testid=empty-message-cta]`).click({ timeout: TIMEOUT });
     });
     const testUserWithXmtpAccount =
       "0x78BfD39428C32Be149892d64bEE6C6f90aedEec1";

--- a/cypress/test_utils.ts
+++ b/cypress/test_utils.ts
@@ -42,7 +42,8 @@ const sendMessages = (
   for (let i = 0; i < numberOfTimes; i++) {
     // Enters message
     checkElement("message-input").type(message);
-    checkElement("message-input-submit").click();
+    checkElement("message-input-submit");
+    cy.get(`[data-testid=message-input-submit]`).click({ timeout: TIMEOUT });
     cy.get(`[data-testid=conversations-list-panel]`, {
       timeout: TIMEOUT,
     }).should("have.length", 1);
@@ -57,7 +58,8 @@ const sendMessages = (
 
   // A way around to solve the message streaming issue
   cy.wait(2000);
-  checkElement("new-message-icon-cta").click();
+  checkElement("new-message-icon-cta");
+  cy.get(`[data-testid=new-message-icon-cta]`).click({ timeout: TIMEOUT });
   checkElement("message-to-input").type(testUser);
 };
 

--- a/cypress/test_utils.ts
+++ b/cypress/test_utils.ts
@@ -43,7 +43,7 @@ const sendMessages = (
     // Enters message
     checkElement("message-input").type(message);
     checkElement("message-input-submit");
-    cy.get(`[data-testid=message-input-submit]`).click({ timeout: TIMEOUT });
+    cy.get(`[data-testid=message-input-submit]`).click();
     cy.get(`[data-testid=conversations-list-panel]`, {
       timeout: TIMEOUT,
     }).should("have.length", 1);
@@ -68,6 +68,7 @@ const checkMessageOutput = (numberOfTimes: number, message: string) => {
     .children()
     .should("have.length", numberOfTimes || 1);
   cy.get(`[data-testid=message-tile-text]`, { timeout: TIMEOUT })
+    .children()
     .last()
     .should("have.text", message);
 };
@@ -91,6 +92,8 @@ export const sendAndEnterMessage = (
   numberOfTimes = 1,
   checkDifferentMessages = false,
 ) => {
+  checkElement("empty-message-cta");
+  cy.get(`[data-testid=empty-message-cta]`).click();
   enterWalletAddress(testUser);
   checkExpectedPreMessageFields();
   sendMessages(numberOfTimes, message, testUser, checkDifferentMessages);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,9 +69,9 @@ const OnboardingPage: NextPage = () => {
         onConnect={openConnectModal}
         onCreate={resolveCreate}
         onEnable={resolveEnable}
-        onDisconnect={() => {
+        onDisconnect={async () => {
           if (client) {
-            disconnectClient();
+            await disconnectClient();
           }
           setStatus(undefined);
           wipeKeys(address ?? "");

--- a/wrappers/MessageContentWrapper.tsx
+++ b/wrappers/MessageContentWrapper.tsx
@@ -9,7 +9,7 @@ const MessageContentWrapper = ({ content }: { content: string }) => {
     shortcodes: ["emojibase"],
   });
   return (
-    <span className="interweave-content">
+    <span className="interweave-content" data-testid="message-tile-text">
       <Interweave
         content={content}
         newWindow


### PR DESCRIPTION
This PR makes a small change to the onDisconnect callback, ensuring the XMTP client is fully disconnected before proceeding to wipe keys, disconnect Wagmi, etc. This helps avoid potential race conditions and ensures a clean disconnect sequence.

Also updates Cypress tests to stabilize our messaging tests. Specifically needed to update a `data-testid` which seems to have moved with the addition of Interweave or the element we needed wasn't always found, and moved a click event out of our beforeEach hook and within the tests at the places they're needed. 