### PR TITLE
Include infura id env in docker build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v3
       - run: docker/build
         env:
-          NEXT_PUBLIC_INFURA_ID: ${{ secrets.NEXT_PUBLIC_INFURA_ID }}
+          NEXT_PUBLIC_INFURA_ID: ${{ secrets.DEV_INFURA_ID }}
       - run: docker/push

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+ARG NEXT_PUBLIC_INFURA_ID
+ENV NEXT_PUBLIC_INFURA_ID=${NEXT_PUBLIC_INFURA_ID}
 RUN npm run build
 
 FROM nginx:alpine

--- a/docker/build
+++ b/docker/build
@@ -5,5 +5,6 @@ set -a; source "${script_dir}/.env.default"; set +a
 
 docker build \
     --tag "${BUILD_CONTAINER_IMAGE}" \
+    --build-arg "NEXT_PUBLIC_INFURA_ID=${NEXT_PUBLIC_INFURA_ID:-}" \
     -f "${script_dir}/Dockerfile" \
     .


### PR DESCRIPTION
This is failing [in the GH workflow](https://github.com/xmtp-labs/xmtp-inbox-web/actions/runs/4820195805/jobs/8585117220) but not when running locally via `docker/build`, and I'm not sure why yet, but it should be failing, and it does fail locally when running `npm run build` without `NEXT_PUBLIC_INFURA_ID` being available. So this PR fixes the failing GH workflow by including the infura ID env. It's a different infura ID than we use for the production deployments though, since these docker images are used for devnets.