### PR TITLE
Fix for expensive Ethers wallet call

### DIFF
--- a/helpers/mockConnector.ts
+++ b/helpers/mockConnector.ts
@@ -1,9 +1,12 @@
 import { MockConnector } from "@wagmi/core/connectors/mock";
 import { Wallet } from "ethers/lib";
 
-const createWallet = Wallet.createRandom();
-
 // mock connector for demos
-export const mockConnector = new MockConnector({
-  options: { signer: createWallet },
-});
+
+export const getMockConnector = () => {
+  const mockWallet = Wallet.createRandom();
+
+  return new MockConnector({
+    options: { signer: mockWallet },
+  });
+};

--- a/hooks/useHandleConnect.ts
+++ b/hooks/useHandleConnect.ts
@@ -1,24 +1,11 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { MockConnector } from "@wagmi/core/connectors/mock";
-import { Wallet } from "ethers/lib";
-import { useConnect } from "wagmi";
 import { isAppEnvDemo } from "../helpers";
 
 const useHandleConnect = () => {
   const { openConnectModal } = useConnectModal();
 
-  const { connect: connectWallet } = useConnect();
-
-  const handleConnectDemo = () => {
-    const createWallet = (() => Wallet.createRandom())();
-    const mockConnector = new MockConnector({
-      options: { signer: createWallet },
-    });
-    connectWallet({ connector: mockConnector });
-  };
-
   return {
-    handleConnect: isAppEnvDemo() ? handleConnectDemo : openConnectModal,
+    handleConnect: !isAppEnvDemo() ? openConnectModal : null,
   };
 };
 

--- a/hooks/useInitXmtpClient.ts
+++ b/hooks/useInitXmtpClient.ts
@@ -9,7 +9,7 @@ import {
   storeKeys,
 } from "../helpers";
 import { useClient, useCanMessage } from "@xmtp/react-sdk";
-import { mockConnector } from "../helpers/mockConnector";
+import { getMockConnector } from "../helpers/mockConnector";
 import { Signer } from "ethers";
 
 type ClientStatus = "new" | "created" | "enabled";
@@ -106,7 +106,7 @@ const useInitXmtpClient = () => {
   // if this is an app demo, connect to the temporary wallet
   useEffect(() => {
     if (isAppEnvDemo()) {
-      connectWallet({ connector: mockConnector });
+      connectWallet({ connector: getMockConnector() });
     }
     if (!client) {
       setStatus(undefined);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useState } from "react";
 import { isAppEnvDemo } from "../helpers";
 import "../i18n";
 import { XMTPProvider } from "@xmtp/react-sdk";
-import { mockConnector } from "../helpers/mockConnector";
+import { getMockConnector } from "../helpers/mockConnector";
 
 const AppWithoutSSR = dynamic(() => import("../components/App"), {
   ssr: false,
@@ -34,7 +34,7 @@ const { connectors } = getDefaultWallets({
 
 const wagmiDemoClient = createClient({
   autoConnect: true,
-  connectors: [mockConnector],
+  connectors: [getMockConnector()],
   provider,
   webSocketProvider,
 });


### PR DESCRIPTION
We have an expensive operation we're doing for demo mode to generate a burner wallet, which is also being done for non-demo views. This takes up ~25% of the scripting time on page load unnecessarily. This PR is to update that logic, and also clean up a related hook with logic we no longer need.
<img width="753" alt="Screenshot 2023-05-04 at 6 36 34 PM" src="https://user-images.githubusercontent.com/35409260/236361756-741aafce-4ba2-41df-ab33-452ebced5a8c.png">
