### PR TITLE
Fix mock connector being called multiple times

### DIFF
--- a/helpers/mockConnector.ts
+++ b/helpers/mockConnector.ts
@@ -5,9 +5,18 @@ import { isAppEnvDemo } from "./env";
 // mock connector for demos
 export const getMockConnector = () => {
   if (typeof window !== "undefined" && isAppEnvDemo()) {
-    const mockWallet = Wallet.createRandom();
-    return new MockConnector({
-      options: { signer: mockWallet },
-    });
+    const storedMockConnector = JSON.parse(
+      sessionStorage.getItem("mockConnector") ?? "{}",
+    );
+    if (!storedMockConnector.connect) {
+      const mockWallet = Wallet.createRandom();
+      const mockConnector = new MockConnector({
+        options: { signer: mockWallet },
+      });
+      sessionStorage.setItem("mockConnector", JSON.stringify(mockConnector));
+      return mockConnector;
+    } else {
+      return storedMockConnector;
+    }
   }
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,29 +32,28 @@ const { connectors } = getDefaultWallets({
   chains,
 });
 
-const wagmiDemoClient = createClient({
-  autoConnect: true,
-  connectors: [(getMockConnector() as Connector) ?? {}],
-  provider,
-  webSocketProvider,
-});
-
-const wagmiClient = createClient({
-  autoConnect: true,
-  connectors,
-  provider,
-  webSocketProvider,
-});
-
 function AppWrapper({ Component, pageProps }: AppProps) {
-  const [client, setClient] = useState<typeof wagmiClient | null>(null);
+  const [client, setClient] = useState<any>(null);
   useEffect(() => {
     if (isAppEnvDemo()) {
+      const wagmiDemoClient = createClient({
+        autoConnect: true,
+        connectors: [(getMockConnector() as Connector) ?? {}],
+        provider,
+        webSocketProvider,
+      });
       setClient(wagmiDemoClient);
     } else {
+      const wagmiClient = createClient({
+        autoConnect: true,
+        connectors,
+        provider,
+        webSocketProvider,
+      });
       setClient(wagmiClient);
     }
   }, []);
+
   return (
     client && (
       <WagmiConfig client={client}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,7 +34,7 @@ const { connectors } = getDefaultWallets({
 
 const wagmiDemoClient = createClient({
   autoConnect: true,
-  connectors: [getMockConnector() as Connector],
+  connectors: [(getMockConnector() as Connector) ?? {}],
   provider,
   webSocketProvider,
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,6 +33,8 @@ const { connectors } = getDefaultWallets({
 });
 
 function AppWrapper({ Component, pageProps }: AppProps) {
+  // setting the type to any because the return
+  // type of createClient is not being exported
   const [client, setClient] = useState<any>(null);
   useEffect(() => {
     if (isAppEnvDemo()) {


### PR DESCRIPTION
Storing the mock connector in the session storage once it is created, to avoid it being set multiple times