### PR TITLE
Added try/catch for ethers check

### DIFF
--- a/helpers/string.ts
+++ b/helpers/string.ts
@@ -1,5 +1,6 @@
 import { Conversation } from "@xmtp/react-sdk";
 import { ALLOWED_ENS_SUFFIXES } from "./constants";
+import { utils } from "ethers";
 
 export const truncate = (str: string | undefined, length: number): string => {
   if (!str) {
@@ -61,4 +62,14 @@ export const getConversationId = (conversation?: Conversation): string => {
   return conversation?.context?.conversationId
     ? `${conversation?.peerAddress}/${conversation?.context?.conversationId}`
     : conversation?.peerAddress ?? "";
+};
+
+export const getAddress = (conversationId: string) => {
+  let addr;
+  try {
+    addr = utils.getAddress(conversationId);
+  } catch {
+    addr = conversationId;
+  }
+  return addr;
 };

--- a/helpers/tests/string.test.ts
+++ b/helpers/tests/string.test.ts
@@ -5,8 +5,10 @@ import {
   shortAddress,
   truncate,
   isValidRecipientAddressFormat,
+  getAddress,
 } from "../string";
 import { expect } from "@jest/globals";
+import { utils } from "ethers";
 
 describe("truncate", () => {
   it("should return the original string if its length is less than the length param", () => {
@@ -99,5 +101,21 @@ describe("isValidRecipientAddressFormat", () => {
   });
   it("should return false if invalid address", () => {
     expect(isValidRecipientAddressFormat("")).toBe(false);
+  });
+});
+
+describe("getAddress", () => {
+  it("should return a valid checksum'd address if conversationId is in expected format", () => {
+    const conversationId = "0x78bfd39428c32be149892d64bee6c6f90aedeec1";
+    expect(getAddress(conversationId)).toBe(utils.getAddress(conversationId));
+  });
+  it("should return the input if conversationId is not in expected format", () => {
+    const conversationId =
+      "0x78bfd39428c32be149892d64bee6c6f90aedeec1/lens.dev/dm/12345";
+
+    expect(getAddress(conversationId)).toBe(conversationId);
+  });
+  it("should handle empty string input and return empty string", () => {
+    expect(getAddress("")).toBe("");
   });
 });

--- a/hooks/useGetMessages.ts
+++ b/hooks/useGetMessages.ts
@@ -1,16 +1,16 @@
 import { DecodedMessage, SortDirection } from "@xmtp/react-sdk";
 import { useCallback, useMemo } from "react";
-import { MESSAGE_LIMIT } from "../helpers";
+import { MESSAGE_LIMIT, getAddress } from "../helpers";
 import { useXmtpStore } from "../store/xmtp";
 import { useMessages } from "@xmtp/react-sdk";
-import { utils } from "ethers";
 
 const useGetMessages = (conversationId: string) => {
   const messages = useXmtpStore((state) =>
     state.convoMessages.get(conversationId),
   );
+
   const conversation = useXmtpStore((state) =>
-    state.conversations.get(utils.getAddress(conversationId) ?? conversationId),
+    state.conversations.get(getAddress(conversationId)),
   );
   const addMessages = useXmtpStore((state) => state.addMessages);
 


### PR DESCRIPTION
This PR includes a fix for non-null convoId conversations, where the Ethers checksum address formatting doesn't work with that format and throws an error. Wrapping this logic in a try/catch instead of using the previous nullish coalescing operator logic.