### PR TITLE
Added image caching with dexie

### DIFF
--- a/component-library/components/FullMessage/FullMessage.tsx
+++ b/component-library/components/FullMessage/FullMessage.tsx
@@ -75,9 +75,6 @@ export const FullMessage = ({
             className={`text-xs text-gray-500 w-full flex mb-4 ${
               isOutgoingMessage ? "justify-end" : "justify-start"
             }`}>
-            {typeof text?.props?.content !== "string" ? (
-              <p className="mx-1">Image</p>
-            ) : null}
             {t("{{datetime, time}}", { datetime })}
           </div>
         </div>

--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -119,6 +119,7 @@ export const MessageInput = ({
         ref={inputFile}
         onChange={onAttachmentChange}
         accept={imageTypes.join(", ")}
+        aria-label="file-picker"
         hidden
       />
       <div
@@ -171,7 +172,7 @@ export const MessageInput = ({
             }}>
             <img
               src={attachmentPreview || ""}
-              alt={"Add filename here"}
+              alt={attachment?.filename}
               style={{
                 position: "relative",
                 width: "95%",

--- a/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -9,6 +9,7 @@ import { useClient } from "@xmtp/react-sdk";
 import { humanFileSize } from "../../../helpers/attachments";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
+import { db } from "../../../db";
 
 type RemoteAttachmentMessageTileProps = {
   content: RemoteAttachment;
@@ -57,15 +58,38 @@ const RemoteAttachmentMessageTile = ({
     handleLoading();
   }, [status, client, content]);
 
-  function load() {
-    setStatus("loadRequested");
-  }
+  const load = (inCache = false) => {
+    // If not in cache, add to cache
+    if (!inCache) {
+      db.attachments
+        .add({ attachment: content.url })
+        .then(() => {
+          setStatus("loadRequested");
+        })
+        .catch((e: Error) => {
+          // If error adding to cache, can silently fail and no need to display an error
+          console.log("Error caching image --> ", e);
+        });
+    } else {
+      setStatus("loadRequested");
+    }
+  };
 
   useEffect(() => {
     // No need to wait
     if (isSelf) {
       load();
     }
+    // Check if this is in cache
+    db.attachments
+      .get({ attachment: content.url })
+      .then(() => {
+        load(true);
+      })
+      .catch((e: Error) => {
+        // If error retrieving from cache, can silently fail and no need to display an error
+        console.log("Error fetching image --> ", e);
+      });
   }, []);
 
   return isError ? (
@@ -75,14 +99,18 @@ const RemoteAttachmentMessageTile = ({
       {status === "loading" || isLoading ? "Loading…" : ""}
       {url ? (
         <Zoom>
-          <img src={url} className="max-h-80 rounded-lg" />
+          <img
+            src={url}
+            className="max-h-80 rounded-lg"
+            alt={content.filename}
+          />
         </Zoom>
       ) : null}
       {status !== "loaded" && !isSelf ? (
         <small>
           {content.filename} - {humanFileSize(content.contentLength)}
           {
-            <button onClick={load} type="button">
+            <button onClick={() => load(false)} type="button">
               - Click to Load
             </button>
           }

--- a/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -50,9 +50,10 @@ const RemoteAttachmentMessageTile = ({
 
           db.attachments
             .add({
-              remoteContentUrl: content.url,
-              attachmentObject: attachment,
-              attachmentUrl: objectURL,
+              contentURL: content.url,
+              filename: attachment.filename,
+              mimetype: attachment.mimeType,
+              contentDataURL: objectURL,
             })
             .then(() => {
               setURL(objectURL);
@@ -82,10 +83,10 @@ const RemoteAttachmentMessageTile = ({
   useEffect(() => {
     // Check if this is in cache
     db.attachments
-      .get({ remoteContentUrl: content.url })
+      .get({ contentURL: content.url })
       .then((attachment) => {
-        if (attachment?.attachmentUrl) {
-          setURL(attachment.attachmentUrl);
+        if (attachment?.contentDataURL) {
+          setURL(attachment.contentDataURL);
           setStatus("loaded");
         } else {
           if (isSelf) {

--- a/db.ts
+++ b/db.ts
@@ -1,10 +1,13 @@
 import Dexie, { Table } from "dexie";
-import { Attachment } from "xmtp-content-type-remote-attachment";
 
 export interface CachedAttachments {
-  attachmentObject: Attachment;
-  attachmentUrl: string;
-  remoteContentUrl: string;
+  // Used as key
+  contentURL: string;
+  // Below fields come directly from the attachment data
+  filename: string;
+  mimetype: string;
+  // Derived from the attachment data
+  contentDataURL: string;
 }
 
 export class RemoteAttachmentDb extends Dexie {
@@ -13,7 +16,7 @@ export class RemoteAttachmentDb extends Dexie {
   constructor() {
     super("remoteAttachments");
     this.version(1).stores({
-      attachments: "id++, remoteContentUrl, attachmentObject, attachmentUrl",
+      attachments: "id++, contentURL, filename, mimetype, contentDataURL",
     });
   }
 }

--- a/db.ts
+++ b/db.ts
@@ -1,0 +1,14 @@
+import Dexie, { Table } from "dexie";
+
+export class RemoteAttachmentDb extends Dexie {
+  attachments!: Table<{ attachment: string }>;
+
+  constructor() {
+    super("remoteAttachments");
+    this.version(1).stores({
+      attachments: "++id, attachment", // Primary key and indexed props
+    });
+  }
+}
+
+export const db = new RemoteAttachmentDb();

--- a/db.ts
+++ b/db.ts
@@ -1,12 +1,19 @@
 import Dexie, { Table } from "dexie";
+import { Attachment } from "xmtp-content-type-remote-attachment";
+
+export interface CachedAttachments {
+  attachmentObject: Attachment;
+  attachmentUrl: string;
+  remoteContentUrl: string;
+}
 
 export class RemoteAttachmentDb extends Dexie {
-  attachments!: Table<{ attachment: string }>;
+  attachments!: Table<CachedAttachments>;
 
   constructor() {
     super("remoteAttachments");
     this.version(1).stores({
-      attachments: "++id, attachment", // Primary key and indexed props
+      attachments: "id++, remoteContentUrl, attachmentObject, attachmentUrl",
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/line-clamp": "^0.4.2",
         "@xmtp/react-sdk": "^1.0.0-preview.36",
         "date-fns": "^2.29.3",
+        "dexie": "^3.2.4",
         "emojibase": "^6.1.0",
         "ethers": "^5.7.2",
         "i18next": "^22.4.13",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tailwindcss/line-clamp": "^0.4.2",
     "@xmtp/react-sdk": "^1.0.0-preview.36",
     "date-fns": "^2.29.3",
+    "dexie": "^3.2.4",
     "emojibase": "^6.1.0",
     "ethers": "^5.7.2",
     "i18next": "^22.4.13",


### PR DESCRIPTION
This PR includes caching for images that have already been loaded, so they don't have to be prompted with a "click to reload" each time.

Also tacking on some small changes to this PR:
* Removing "Image" text next to timestamp. 
* Updated some things for a11y like alt tags and aria-labels

While our E2E tests are temporarily disabled, just going to add a note in all my PR overviews a confirmation that these pass locally. 