### PR TITLE
Loose ends for remote image attachments 

### DIFF
--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -119,7 +119,7 @@ export const MessageInput = ({
         ref={inputFile}
         onChange={onAttachmentChange}
         accept={imageTypes.join(", ")}
-        aria-label="file-picker"
+        aria-label={t("aria_labels.filepicker") || "File picker"}
         hidden
       />
       <div
@@ -165,22 +165,12 @@ export const MessageInput = ({
           />
         ) : (
           <div
-            style={{
-              position: "relative",
-              // Required to preserve aspect ratio
-              paddingBottom: "5%",
-            }}>
+            // Bottom padding required to preserve aspect ratio
+            className="relative pb-[5%]">
             <img
               src={attachmentPreview || ""}
               alt={attachment?.filename}
-              style={{
-                position: "relative",
-                width: "95%",
-                minHeight: "100px",
-                maxHeight: "300px",
-                borderRadius: "12px",
-                overflow: "auto",
-              }}></img>
+              className="relative w-95/100 min-h-[100px] max-h-80 rounded-xl overflow-auto"></img>
             <XCircleIcon
               width={20}
               fill="gray"

--- a/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -10,6 +10,7 @@ import { humanFileSize } from "../../../helpers/attachments";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 import { db } from "../../../db";
+import { useTranslation } from "react-i18next";
 
 type RemoteAttachmentMessageTileProps = {
   content: RemoteAttachment;
@@ -28,6 +29,7 @@ const RemoteAttachmentMessageTile = ({
 }: RemoteAttachmentMessageTileProps) => {
   const [status, setStatus] = useState<status>("unloaded");
   const [url, setURL] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const { client } = useClient();
 
@@ -104,10 +106,10 @@ const RemoteAttachmentMessageTile = ({
   }, []);
 
   return isError ? (
-    <p className="text-red-600 p-0">Sorry, an error occurred.</p>
+    <p className="text-red-600 p-0">{t("status_messaging.error_1_header")}</p>
   ) : (
     <div>
-      {status === "loading" || isLoading ? "Loading…" : ""}
+      {status === "loading" || isLoading ? t("status_messaging.loading") : ""}
       {url ? (
         <Zoom>
           <img
@@ -122,7 +124,7 @@ const RemoteAttachmentMessageTile = ({
           {content.filename} - {humanFileSize(content.contentLength)}
           {
             <button onClick={() => load(false)} type="button">
-              - Click to Load
+              {`- ${t("messages.attachment_cta")}`}
             </button>
           }
         </small>

--- a/helpers/attachments.ts
+++ b/helpers/attachments.ts
@@ -1,3 +1,5 @@
+import { ATTACHMENT_ERRORS } from "./constants";
+
 /**
  * Returns a human readable file size string.
  *
@@ -9,7 +11,7 @@
 export const humanFileSize = (bytes: number, si = false, dp = 1) => {
   // Throws error if > 100 MB
   if (bytes > 100000000) {
-    throw new Error("File too large!");
+    return ATTACHMENT_ERRORS.FILE_TOO_LARGE;
   }
   const thresh = si ? 1000 : 1024;
 

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -41,3 +41,7 @@ export const ALLOWED_UNS_SUFFIXES = [
 
 export const XMTP_FEEDBACK_ADDRESS =
   "0x8bcF8AFF8Cb99335CD9f4d9866a40e05E23373ff";
+
+export const ATTACHMENT_ERRORS = {
+  FILE_TOO_LARGE: "File too large",
+};

--- a/helpers/tests/attachments.test.ts
+++ b/helpers/tests/attachments.test.ts
@@ -1,5 +1,6 @@
 import { humanFileSize } from "../attachments";
 import { expect } from "@jest/globals";
+import { ATTACHMENT_ERRORS } from "../constants";
 
 describe("humanFileSize", () => {
   it("should return '0 B' for 0 bytes", () => {
@@ -12,6 +13,6 @@ describe("humanFileSize", () => {
     expect(humanFileSize(1048576)).toBe("1.0 MB");
   });
   it("should throw an error if file is > 100 MB", () => {
-    expect(() => humanFileSize(1000000001)).toThrowError("File too large!");
+    expect(humanFileSize(1000000001)).toBe(ATTACHMENT_ERRORS.FILE_TOO_LARGE);
   });
 });

--- a/hooks/useAttachmentChange.tsx
+++ b/hooks/useAttachmentChange.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useCallback, useState } from "react";
 import { Attachment } from "xmtp-content-type-remote-attachment";
 import { humanFileSize } from "../helpers/attachments";
 import { ATTACHMENT_ERRORS } from "../helpers";
+import { useTranslation } from "react-i18next";
 
 export const imageTypes = ["image/jpg", "image/jpeg", "image/png", "image/gif"];
 
@@ -16,6 +17,8 @@ export const useAttachmentChange = ({
   setAttachmentPreview,
   setIsDragActive,
 }: useAttachmentChangeProps) => {
+  const { t } = useTranslation();
+
   const [error, setError]: [string, Function] = useState("");
 
   const onAttachmentChange = useCallback(
@@ -39,12 +42,15 @@ export const useAttachmentChange = ({
 
         // Currently images are the only attachment type supported
         if (!imageTypes.includes(file.type)) {
-          setError("File must be of valid file format");
+          setError(t("status_messaging.file_invalid_format"));
+          setIsDragActive(false);
           return;
         }
         // Displays error if > 100 MB
         if (humanFileSize(file.size) === ATTACHMENT_ERRORS.FILE_TOO_LARGE) {
-          setError("File too large!");
+          setError(t("status_messaging.file_too_large"));
+          setIsDragActive(false);
+          return;
         }
         const fileReader = new FileReader();
         fileReader.addEventListener("load", async () => {

--- a/hooks/useAttachmentChange.tsx
+++ b/hooks/useAttachmentChange.tsx
@@ -1,5 +1,7 @@
 import { ChangeEvent, useCallback, useState } from "react";
 import { Attachment } from "xmtp-content-type-remote-attachment";
+import { humanFileSize } from "../helpers/attachments";
+import { ATTACHMENT_ERRORS } from "../helpers";
 
 export const imageTypes = ["image/jpg", "image/jpeg", "image/png", "image/gif"];
 
@@ -39,6 +41,10 @@ export const useAttachmentChange = ({
         if (!imageTypes.includes(file.type)) {
           setError("File must be of valid file format");
           return;
+        }
+        // Displays error if > 100 MB
+        if (humanFileSize(file.size) === ATTACHMENT_ERRORS.FILE_TOO_LARGE) {
+          setError("File too large!");
         }
         const fileReader = new FileReader();
         fileReader.addEventListener("load", async () => {

--- a/hooks/useSendMessage.ts
+++ b/hooks/useSendMessage.ts
@@ -17,8 +17,10 @@ import {
 import { AttachmentCodec } from "xmtp-content-type-remote-attachment";
 import { Web3Storage } from "web3.storage";
 import Upload from "../classes/Upload";
+import { useTranslation } from "react-i18next";
 
 const useSendMessage = (conversationId: address, attachment?: Attachment) => {
+  const { t } = useTranslation();
   const conversations = useXmtpStore((state) => state.conversations);
   let selectedConversation = conversations.get(conversationId);
   const { startConversation, error, isLoading } = useStartConversation<
@@ -77,7 +79,10 @@ const useSendMessage = (conversationId: address, attachment?: Attachment) => {
             recipientWalletAddress,
             remoteAttachment,
             {
-              contentFallback: remoteAttachment.filename,
+              contentFallback:
+                t("status_messaging.file_unsupported", {
+                  FILENAME: remoteAttachment.filename,
+                }) || remoteAttachment.filename,
               contentType: ContentTypeRemoteAttachment,
             },
           );
@@ -88,7 +93,10 @@ const useSendMessage = (conversationId: address, attachment?: Attachment) => {
           }
         } else {
           await sendMessageFromHook(remoteAttachment, {
-            contentFallback: remoteAttachment.filename,
+            contentFallback:
+              t("status_messaging.file_unsupported", {
+                FILENAME: remoteAttachment.filename,
+              }) || remoteAttachment.filename,
             contentType: ContentTypeRemoteAttachment,
           });
         }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -18,6 +18,8 @@
     "enabling_subheader": "Click <strong>Sign</strong> to create your password. You'll be prompted to click <strong>Sign</strong> to provide it whenever you access your inbox."
   },
   "messages": {
+    "attachment": "Attachment",
+    "attachment_cta": "Click to load",
     "filter_none": "All messages",
     "filter_requests": "Message requests",
     "convos_empty_header": "No messages? No problem.",
@@ -50,7 +52,11 @@
   "status_messaging": {
     "error_1_header": "Sorry, the app encountered an error",
     "error_1_subheader": "Not to worry. Let’s try again. If the error persists, <0>we're here to help!</0>",
-    "error_1_button": "Try again"
+    "error_1_button": "Try again",
+    "file_invalid_format": "File must be of valid file format",
+    "file_too_large": "File too large",
+    "file_unsupported": "[Attachment] Cannot display {{FILENAME}}. This app does not support attachments yet.",
+    "loading": "Loading..."
   },
   "common": {
     "disconnect": "Disconnect wallet",
@@ -65,6 +71,7 @@
   },
   "aria_labels": {
     "address_input": "Address input",
+    "filepicker": "File picker",
     "start_message": "Start new message",
     "submit_message": "Submit message"
   }

--- a/pages/inbox.tsx
+++ b/pages/inbox.tsx
@@ -14,6 +14,7 @@ import { useDisconnect, useSigner } from "wagmi";
 import { ConversationListWrapper } from "../wrappers/ConversationListWrapper";
 import { useAttachmentChange } from "../hooks/useAttachmentChange";
 import { Attachment } from "xmtp-content-type-remote-attachment";
+import { db } from "../db";
 
 export type address = "0x${string}";
 
@@ -26,6 +27,10 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
     if (!client) {
       router.push("/");
     }
+    // any time the client changes, the attachments cached db should be cleared
+    // this is because the contentDataURL is partially derived from client
+    // and doesn't render properly if image is in cache with a different client.
+    db.attachments.clear();
   }, [client]);
 
   const { data: signer } = useSigner();

--- a/wrappers/MessagePreviewCardWrapper.tsx
+++ b/wrappers/MessagePreviewCardWrapper.tsx
@@ -12,6 +12,7 @@ import {
 import { address } from "../pages/inbox";
 import { useXmtpStore } from "../store/xmtp";
 import MessageContentWrapper from "./MessageContentWrapper";
+import { useTranslation } from "react-i18next";
 
 interface MessagePreviewCardWrapperProps {
   convo?: Conversation;
@@ -19,6 +20,7 @@ interface MessagePreviewCardWrapperProps {
 export const MessagePreviewCardWrapper = ({
   convo,
 }: MessagePreviewCardWrapperProps) => {
+  const { t } = useTranslation();
   // XMTP State
   const previewMessages = useXmtpStore((state) => state.previewMessages);
   const recipientWalletAddress = useXmtpStore(
@@ -79,7 +81,7 @@ export const MessagePreviewCardWrapper = ({
           <MessageContentWrapper
             content={
               typeof previewMessage.content !== "string"
-                ? "Attachment"
+                ? t("messages.attachment") || "Attachment"
                 : previewMessage?.content
             }
             // None of these props are needed for this preview view.


### PR DESCRIPTION
PR includes: 

- Removing hardcoded text in favor of dynamic text for i18n
- Smoothed out error handling for files > 100MB
- Fixed bug where indexDB needed to be cleared when client was changed or image data wasn't properly displayed
- Moved some inline CSS to tailwind; even though we'll eventually scrap tailwind, wanted to keep the styling consistent in the meantime