### PR TITLE
Safari attachments fix

### DIFF
--- a/attachments/Attachment.tsx
+++ b/attachments/Attachment.tsx
@@ -1,0 +1,40 @@
+import { ContentCodec, ContentTypeId, EncodedContent } from "@xmtp/xmtp-js";
+import { CodecRegistry } from "@xmtp/xmtp-js/dist/types/src/MessageContent";
+
+export const ContentTypeAttachment = new ContentTypeId({
+  authorityId: "xmtp.org",
+  typeId: "attachment",
+  versionMajor: 1,
+  versionMinor: 0,
+});
+
+export type Attachment = {
+  filename: string;
+  mimeType: string;
+  data: Uint8Array;
+};
+
+export class AttachmentCodec implements ContentCodec<Attachment> {
+  get contentType(): ContentTypeId {
+    return ContentTypeAttachment;
+  }
+
+  encode(content: Attachment, registry: CodecRegistry): EncodedContent {
+    return {
+      type: ContentTypeAttachment,
+      parameters: {
+        filename: content.filename,
+        mimeType: content.mimeType,
+      },
+      content: content.data,
+    };
+  }
+
+  decode(content: EncodedContent, registry: CodecRegistry): Attachment {
+    return {
+      filename: content.parameters.filename,
+      mimeType: content.parameters.mimeType,
+      data: content.content,
+    };
+  }
+}

--- a/attachments/Attachment.tsx
+++ b/attachments/Attachment.tsx
@@ -1,5 +1,5 @@
+import { CodecRegistry } from "@xmtp/react-sdk";
 import { ContentCodec, ContentTypeId, EncodedContent } from "@xmtp/xmtp-js";
-import { CodecRegistry } from "@xmtp/xmtp-js/dist/types/src/MessageContent";
 
 export const ContentTypeAttachment = new ContentTypeId({
   authorityId: "xmtp.org",

--- a/attachments/RemoteAttachment.tsx
+++ b/attachments/RemoteAttachment.tsx
@@ -1,0 +1,166 @@
+import {
+  Ciphertext,
+  ContentCodec,
+  ContentTypeId,
+  EncodedContent,
+  encrypt,
+  decrypt,
+} from "@xmtp/xmtp-js";
+import * as secp from "@noble/secp256k1";
+import { CodecRegistry } from "@xmtp/xmtp-js/dist/types/src/MessageContent";
+import { crypto } from "./encryption";
+import { content as proto } from "@xmtp/proto";
+
+export const ContentTypeRemoteAttachment = new ContentTypeId({
+  authorityId: "xmtp.org",
+  typeId: "remoteStaticAttachment",
+  versionMajor: 1,
+  versionMinor: 0,
+});
+
+export type EncryptedEncodedContent = {
+  digest: string;
+  salt: Uint8Array;
+  nonce: Uint8Array;
+  secret: Uint8Array;
+  payload: Uint8Array;
+};
+
+export type RemoteAttachment = {
+  url: string;
+  contentDigest: string;
+  salt: Uint8Array;
+  nonce: Uint8Array;
+  secret: Uint8Array;
+  scheme: string;
+  contentLength: number;
+  filename: string;
+};
+
+export class RemoteAttachmentCodec implements ContentCodec<RemoteAttachment> {
+  static async load<T>(
+    remoteAttachment: RemoteAttachment,
+    codecRegistry: CodecRegistry,
+  ): Promise<T> {
+    const response = await fetch(remoteAttachment.url);
+    const payload = new Uint8Array(await response.arrayBuffer());
+
+    if (!payload) {
+      throw "no payload for remote attachment at " + remoteAttachment.url;
+    }
+
+    const digestBytes = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", payload),
+    );
+    const digest = secp.utils.bytesToHex(digestBytes);
+
+    if (digest !== remoteAttachment.contentDigest) {
+      throw new Error("content digest does not match");
+    }
+
+    const ciphertext = new Ciphertext({
+      aes256GcmHkdfSha256: {
+        hkdfSalt: remoteAttachment.salt,
+        gcmNonce: remoteAttachment.nonce,
+        payload: payload,
+      },
+    });
+
+    const encodedContentData = await decrypt(
+      ciphertext,
+      remoteAttachment.secret,
+    );
+    const encodedContent = proto.EncodedContent.decode(encodedContentData);
+
+    if (!encodedContent || !encodedContent.type) {
+      throw "no encoded content";
+    }
+
+    const contentType = encodedContent.type;
+    if (!contentType) {
+      throw "no content type";
+    }
+
+    const codec = codecRegistry.codecFor(new ContentTypeId(contentType));
+
+    if (!codec) {
+      throw "no codec found for " + encodedContent.type?.typeId;
+    }
+
+    return codec.decode(encodedContent as EncodedContent, codecRegistry);
+  }
+
+  static async encodeEncrypted<T>(
+    content: T,
+    codec: ContentCodec<T>,
+  ): Promise<EncryptedEncodedContent> {
+    const secret = crypto.getRandomValues(new Uint8Array(32));
+    const encodedContent = proto.EncodedContent.encode(
+      codec.encode(content, {
+        codecFor(contentType: ContentTypeId) {
+          return undefined;
+        },
+      }),
+    ).finish();
+    const ciphertext = await encrypt(encodedContent, secret);
+    const salt = ciphertext.aes256GcmHkdfSha256?.hkdfSalt;
+    const nonce = ciphertext.aes256GcmHkdfSha256?.gcmNonce;
+    const payload = ciphertext.aes256GcmHkdfSha256?.payload;
+
+    if (!salt || !nonce || !payload) {
+      throw "missing encryption key";
+    }
+
+    console.log(`encode payload`, payload);
+
+    const digestBytes = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", payload),
+    );
+    const digest = secp.utils.bytesToHex(digestBytes);
+
+    return {
+      digest,
+      secret,
+      salt,
+      nonce,
+      payload,
+    };
+  }
+
+  get contentType(): ContentTypeId {
+    return ContentTypeRemoteAttachment;
+  }
+
+  encode(content: RemoteAttachment, registry: CodecRegistry): EncodedContent {
+    if (!content.url.startsWith("https")) {
+      throw new Error("scheme must be https");
+    }
+
+    return {
+      type: ContentTypeRemoteAttachment,
+      parameters: {
+        contentDigest: content.contentDigest,
+        salt: secp.utils.bytesToHex(content.salt),
+        nonce: secp.utils.bytesToHex(content.nonce),
+        secret: secp.utils.bytesToHex(content.secret),
+        scheme: content.scheme,
+        contentLength: String(content.contentLength),
+        filename: content.filename,
+      },
+      content: new TextEncoder().encode(content.url),
+    };
+  }
+
+  decode(content: EncodedContent, registry: CodecRegistry): RemoteAttachment {
+    return {
+      url: new TextDecoder().decode(content.content),
+      contentDigest: content.parameters.contentDigest,
+      salt: secp.utils.hexToBytes(content.parameters.salt),
+      nonce: secp.utils.hexToBytes(content.parameters.nonce),
+      secret: secp.utils.hexToBytes(content.parameters.secret),
+      scheme: content.parameters.scheme,
+      contentLength: parseInt(content.parameters.contentLength),
+      filename: content.parameters.filename,
+    };
+  }
+}

--- a/attachments/encryption.ts
+++ b/attachments/encryption.ts
@@ -1,0 +1,6 @@
+// crypto should provide access to standard Web Crypto API
+// in both the browser environment and node.
+export const crypto: Crypto =
+  typeof window !== "undefined"
+    ? window.crypto
+    : (require("crypto").webcrypto as unknown as Crypto);

--- a/attachments/index.ts
+++ b/attachments/index.ts
@@ -1,0 +1,10 @@
+export { AttachmentCodec, ContentTypeAttachment } from "./Attachment";
+export type { Attachment } from "./Attachment";
+export {
+  RemoteAttachmentCodec,
+  ContentTypeRemoteAttachment,
+} from "./RemoteAttachment";
+export type {
+  RemoteAttachment,
+  EncryptedEncodedContent,
+} from "./RemoteAttachment";

--- a/attachments/utils.ts
+++ b/attachments/utils.ts
@@ -1,0 +1,6 @@
+// This is a variation of https://github.com/paulmillr/noble-secp256k1/blob/main/index.ts#L1378-L1388
+// that uses `digest('SHA-256', bytes)` instead of `digest('SHA-256', bytes.buffer)`
+// which seems to produce different results.
+export async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}

--- a/component-library/components/FullMessage/FullMessage.stories.tsx
+++ b/component-library/components/FullMessage/FullMessage.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { FullMessage } from "./FullMessage";
 import { shortAddress } from "../../../helpers";
 import MessageContentWrapper from "../../../wrappers/MessageContentWrapper";
-import { RemoteAttachment } from "xmtp-content-type-remote-attachment";
+import { RemoteAttachment } from "../../../attachments";
 
 export default {
   title: "FullMessage",

--- a/component-library/components/MessageInput/MessageInput.tsx
+++ b/component-library/components/MessageInput/MessageInput.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useLayoutEffect, useRef } from "react";
-import { Attachment } from "xmtp-content-type-remote-attachment";
+import { Attachment } from "../../../attachments";
 import { ArrowUpIcon, PaperClipIcon } from "@heroicons/react/outline";
 import { IconButton } from "../IconButton/IconButton";
 import { classNames } from "../../../helpers";

--- a/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -3,7 +3,7 @@ import {
   Attachment,
   RemoteAttachment,
   RemoteAttachmentCodec,
-} from "xmtp-content-type-remote-attachment";
+} from "../../../attachments";
 import React from "react";
 import { useClient } from "@xmtp/react-sdk";
 import { humanFileSize } from "../../../helpers/attachments";

--- a/hooks/useAttachmentChange.tsx
+++ b/hooks/useAttachmentChange.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useCallback, useState } from "react";
-import { Attachment } from "xmtp-content-type-remote-attachment";
+import { Attachment } from "../attachments";
 import { humanFileSize } from "../helpers/attachments";
 import { ATTACHMENT_ERRORS } from "../helpers";
 import { useTranslation } from "react-i18next";

--- a/hooks/useInitXmtpClient.ts
+++ b/hooks/useInitXmtpClient.ts
@@ -11,10 +11,9 @@ import {
 import { useClient, useCanMessage } from "@xmtp/react-sdk";
 import { mockConnector } from "../helpers/mockConnector";
 import { Signer } from "ethers";
-import {
-  AttachmentCodec,
-  RemoteAttachmentCodec,
-} from "xmtp-content-type-remote-attachment";
+
+import { RemoteAttachmentCodec } from "../attachments/RemoteAttachment";
+import { AttachmentCodec } from "../attachments/Attachment";
 
 type ClientStatus = "new" | "created" | "enabled";
 

--- a/hooks/useSendMessage.ts
+++ b/hooks/useSendMessage.ts
@@ -13,8 +13,8 @@ import {
   RemoteAttachment,
   ContentTypeRemoteAttachment,
   RemoteAttachmentCodec,
-} from "xmtp-content-type-remote-attachment";
-import { AttachmentCodec } from "xmtp-content-type-remote-attachment";
+} from "../attachments";
+import { AttachmentCodec } from "../attachments";
 import { Web3Storage } from "web3.storage";
 import Upload from "../classes/Upload";
 import { useTranslation } from "react-i18next";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@rainbow-me/rainbowkit": "^0.12.8",
         "@tailwindcss/line-clamp": "^0.4.2",
         "@xmtp/react-sdk": "^1.0.0-preview.36",
+        "@xmtp/xmtp-js": "^9.1.1",
         "date-fns": "^2.29.3",
         "dexie": "^3.2.4",
         "emojibase": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@rainbow-me/rainbowkit": "^0.12.8",
         "@tailwindcss/line-clamp": "^0.4.2",
         "@xmtp/react-sdk": "^1.0.0-preview.36",
-        "@xmtp/xmtp-js": "^9.1.1",
         "date-fns": "^2.29.3",
         "dexie": "^3.2.4",
         "emojibase": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "storybook": "^7.0.17",
         "wagmi": "^0.12.10",
         "web3.storage": "^4.5.4",
-        "xmtp-content-type-remote-attachment": "^1.0.7",
         "zustand": "^4.3.2"
       },
       "devDependencies": {
@@ -5375,11 +5374,6 @@
         "@stablelib/random": "^1.0.2",
         "@stablelib/wipe": "^1.0.1"
       }
-    },
-    "node_modules/@stardazed/streams-polyfill": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stardazed/streams-polyfill/-/streams-polyfill-2.4.0.tgz",
-      "integrity": "sha512-W6Yg9cA8YT1b9qCQsz/2+kmKt7i/Za2Nj4QOLqdiANzpTiGy5mOyCQNyh0CVpbvXkjCBo2QxrwPvbDlP9u9k+Q=="
     },
     "node_modules/@storybook/addon-actions": {
       "version": "7.0.17",
@@ -13395,15 +13389,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -13459,7 +13444,7 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -13674,7 +13659,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -13904,7 +13889,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/bufferutil": {
       "version": "4.0.7",
@@ -14322,7 +14307,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -14820,7 +14805,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -14833,7 +14818,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -16122,20 +16107,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -16161,57 +16132,6 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0"
-      },
-      "optionalDependencies": {
-        "secp256k1": "3.7.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/eccrypto/node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
-    "node_modules/eccrypto/node_modules/secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/ee-first": {
@@ -17830,7 +17750,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -19412,7 +19332,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -19426,7 +19346,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25031,7 +24951,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -28976,7 +28896,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -32956,30 +32876,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xmtp-content-type-remote-attachment": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/xmtp-content-type-remote-attachment/-/xmtp-content-type-remote-attachment-1.0.7.tgz",
-      "integrity": "sha512-lBkKSITbK52Kw8uG2FQcJ1JqxK3yO7XsdDgV+RSaHlfRBskAA0Xg7BEUIrY9wsAtFNzs77gZk3cwo7yzqy71lg==",
-      "dependencies": {
-        "@noble/secp256k1": "^1.7.1",
-        "@xmtp/proto": "^3.15.0",
-        "@xmtp/xmtp-js": "^7.12.0"
-      }
-    },
-    "node_modules/xmtp-content-type-remote-attachment/node_modules/@xmtp/xmtp-js": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.14.2.tgz",
-      "integrity": "sha512-HU3xn4IEOA81mC51DHSo0k9n87TYUqcg0RG5s+ThkdeyQbnaV4h9AApD+AXE2zeDK9ThJA3qsKcODnf88SCAWQ==",
-      "dependencies": {
-        "@noble/secp256k1": "^1.5.2",
-        "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.15.0",
-        "async-mutex": "^0.4.0",
-        "eccrypto": "^1.1.6",
-        "ethers": "^5.5.3",
-        "long": "^5.2.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -36729,11 +36625,6 @@
         "@stablelib/random": "^1.0.2",
         "@stablelib/wipe": "^1.0.1"
       }
-    },
-    "@stardazed/streams-polyfill": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stardazed/streams-polyfill/-/streams-polyfill-2.4.0.tgz",
-      "integrity": "sha512-W6Yg9cA8YT1b9qCQsz/2+kmKt7i/Za2Nj4QOLqdiANzpTiGy5mOyCQNyh0CVpbvXkjCBo2QxrwPvbDlP9u9k+Q=="
     },
     "@storybook/addon-actions": {
       "version": "7.0.17",
@@ -42960,15 +42851,6 @@
       "integrity": "sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==",
       "dev": true
     },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -43024,7 +42906,7 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "devOptional": true
+      "dev": true
     },
     "body-parser": {
       "version": "1.20.1",
@@ -43196,7 +43078,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -43377,7 +43259,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "devOptional": true
+      "dev": true
     },
     "bufferutil": {
       "version": "4.0.7",
@@ -43679,7 +43561,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -44070,7 +43952,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -44083,7 +43965,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -45038,17 +44920,6 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -45074,46 +44945,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "requires": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0",
-        "secp256k1": "3.7.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
-        },
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        },
-        "secp256k1": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.4.1",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
       }
     },
     "ee-first": {
@@ -46438,7 +46269,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -47623,7 +47454,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -47634,7 +47465,7 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -51873,7 +51704,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -54830,7 +54661,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -57926,32 +57757,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmtp-content-type-remote-attachment": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/xmtp-content-type-remote-attachment/-/xmtp-content-type-remote-attachment-1.0.7.tgz",
-      "integrity": "sha512-lBkKSITbK52Kw8uG2FQcJ1JqxK3yO7XsdDgV+RSaHlfRBskAA0Xg7BEUIrY9wsAtFNzs77gZk3cwo7yzqy71lg==",
-      "requires": {
-        "@noble/secp256k1": "^1.7.1",
-        "@xmtp/proto": "^3.15.0",
-        "@xmtp/xmtp-js": "^7.12.0"
-      },
-      "dependencies": {
-        "@xmtp/xmtp-js": {
-          "version": "7.14.2",
-          "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.14.2.tgz",
-          "integrity": "sha512-HU3xn4IEOA81mC51DHSo0k9n87TYUqcg0RG5s+ThkdeyQbnaV4h9AApD+AXE2zeDK9ThJA3qsKcODnf88SCAWQ==",
-          "requires": {
-            "@noble/secp256k1": "^1.5.2",
-            "@stardazed/streams-polyfill": "^2.4.0",
-            "@xmtp/proto": "^3.15.0",
-            "async-mutex": "^0.4.0",
-            "eccrypto": "^1.1.6",
-            "ethers": "^5.5.3",
-            "long": "^5.2.0"
-          }
-        }
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "storybook": "^7.0.17",
     "wagmi": "^0.12.10",
     "web3.storage": "^4.5.4",
-    "xmtp-content-type-remote-attachment": "^1.0.7",
     "zustand": "^4.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "storybook": "^7.0.17",
     "wagmi": "^0.12.10",
     "web3.storage": "^4.5.4",
+    "@xmtp/xmtp-js": "^9.1.1",
     "zustand": "^4.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "storybook": "^7.0.17",
     "wagmi": "^0.12.10",
     "web3.storage": "^4.5.4",
-    "@xmtp/xmtp-js": "^9.1.1",
     "zustand": "^4.3.2"
   },
   "devDependencies": {

--- a/pages/inbox.tsx
+++ b/pages/inbox.tsx
@@ -13,7 +13,7 @@ import { useClient } from "@xmtp/react-sdk";
 import { useDisconnect, useSigner } from "wagmi";
 import { ConversationListWrapper } from "../wrappers/ConversationListWrapper";
 import { useAttachmentChange } from "../hooks/useAttachmentChange";
-import { Attachment } from "xmtp-content-type-remote-attachment";
+import { Attachment } from "../attachments";
 import { db } from "../db";
 
 export type address = "0x${string}";

--- a/wrappers/MessageContentWrapper.tsx
+++ b/wrappers/MessageContentWrapper.tsx
@@ -4,7 +4,7 @@ import { EmojiMatcher, useEmojiData } from "interweave-emoji";
 import type { MouseEvent } from "react";
 import React from "react";
 import RemoteAttachmentMessageTile from "../component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile";
-import { RemoteAttachment } from "xmtp-content-type-remote-attachment";
+import { RemoteAttachment } from "../attachments";
 
 interface MessageContentWrapperProps {
   content: string | RemoteAttachment;

--- a/wrappers/MessageInputWrapper.tsx
+++ b/wrappers/MessageInputWrapper.tsx
@@ -5,7 +5,7 @@ import useGetRecipientInputMode from "../hooks/useGetRecipientInputMode";
 import useSendMessage from "../hooks/useSendMessage";
 import { useXmtpStore } from "../store/xmtp";
 import { address } from "../pages/inbox";
-import { Attachment } from "xmtp-content-type-remote-attachment";
+import { Attachment } from "../attachments";
 
 interface MessageInputWrapperProps {
   attachment?: Attachment;


### PR DESCRIPTION
On non-Chromium browsers like Safari, login was blocked due to an error from the content attachment package. The error was thrown from the Cache API, which isn't being used anywhere that I can tell in this package, so I pulled the code from the package into the repo directly to debug, where it then worked. 

I will continue investigating this to find a more optimal solution. But in the meantime, since this was a blocker for images, pushing up this workaround. 