### PR TITLE
Use vite output dir in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .git
 .next
 node_modules
-out
+dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ RUN npm ci
 COPY . .
 ARG VITE_INFURA_ID
 ENV VITE_INFURA_ID=${VITE_INFURA_ID}
+ENV VITE_XMTP_API_URL=PLACEHOLDER_XMTP_API_URL
 RUN npm run build
 
 FROM nginx:alpine
@@ -12,6 +13,5 @@ RUN apk update && \
     apk add bash
 COPY docker/entrypoint.sh /opt/
 COPY docker/nginx-default-template.conf /app/
-COPY --from=builder /app/out /app/html-template
-ENV VITE_XMTP_API_URL=PLACEHOLDER_XMTP_API_URL
+COPY --from=builder /app/dist /app/html-template
 CMD ["/opt/entrypoint.sh"]


### PR DESCRIPTION
Fixes the docker build failure in https://github.com/xmtp-labs/xmtp-inbox-web/pull/313