### PR TITLE
Initial support for documents and videos

### DIFF
--- a/src/component-library/components/IconButton/IconButton.tsx
+++ b/src/component-library/components/IconButton/IconButton.tsx
@@ -70,7 +70,7 @@ export const IconButton = ({
   const shape =
     variant === "primary"
       ? "rounded-full"
-      : "rounded-tl-2xl rounded-tr-2xl rounded-bl-2xl";
+      : "rounded-tl-2xl rounded-tr-2xl rounded-br-2xl";
 
   return (
     <button

--- a/src/component-library/components/MessageInput/MessageInput.tsx
+++ b/src/component-library/components/MessageInput/MessageInput.tsx
@@ -1,17 +1,37 @@
-import React, { ChangeEvent, useEffect, useLayoutEffect, useRef } from "react";
+import {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Attachment } from "xmtp-content-type-remote-attachment";
-import { ArrowUpIcon, PaperClipIcon } from "@heroicons/react/outline";
+import { ArrowUpIcon } from "@heroicons/react/outline";
 import { IconButton } from "../IconButton/IconButton";
-import { classNames } from "../../../../src/helpers";
 import { useTranslation } from "react-i18next";
-import { XCircleIcon } from "@heroicons/react/solid";
-import { useAttachmentChange } from "../../../../src/hooks/useAttachmentChange";
+import {
+  DocumentIcon,
+  PhotographIcon,
+  VideoCameraIcon,
+  XCircleIcon,
+} from "@heroicons/react/outline";
+import {
+  typeLookup,
+  useAttachmentChange,
+} from "../../../../src/hooks/useAttachmentChange";
+import { contentTypes } from "../../../helpers/attachments";
+import { classNames } from "../../../helpers";
 
 interface InputProps {
   /**
    * What happens on a submit?
    */
-  onSubmit?: (msg: string | Attachment) => Promise<void>;
+  onSubmit?: (
+    msg: string | Attachment,
+    type: "attachment" | "text",
+  ) => Promise<void>;
   /**
    * Is the CTA button disabled?
    */
@@ -54,15 +74,17 @@ export const MessageInput = ({
 }: InputProps) => {
   const { t } = useTranslation();
   let textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const [value, setValue] = React.useState("");
+  const [value, setValue] = useState("");
+  const [acceptedTypes, setAcceptedTypes]: [
+    string[] | undefined,
+    Dispatch<SetStateAction<string[] | undefined>>,
+  ] = useState();
 
   const inputFile = useRef<HTMLInputElement | null>(null);
 
   const onChange = (event: ChangeEvent<HTMLTextAreaElement>) =>
     setValue(event.target.value);
 
-  const borderStyles =
-    "border border-gray-300 focus-within:border-1 focus-within:border-indigo-600 rounded-tl-3xl rounded-bl-3xl rounded-tr-3xl";
   const textAreaStyles = `${
     textAreaRef?.current?.scrollHeight &&
     textAreaRef?.current?.scrollHeight <= 32
@@ -89,10 +111,20 @@ export const MessageInput = ({
     setAttachmentPreview(undefined);
   }, [conversationId]);
 
-  const onButtonClick = () => {
-    // Current points to the mounted file input element
-    inputFile?.current?.click();
+  const onButtonClick = (contentType: contentTypes) => {
+    const acceptedFileTypeList = Object.keys(typeLookup).reduce(
+      (acc: string[], key: string) => {
+        if (typeLookup[key] === contentType) acc.push(`.${key}`);
+        return acc;
+      },
+      [],
+    );
+    setAcceptedTypes([...acceptedFileTypeList]);
   };
+
+  useEffect(() => {
+    inputFile?.current?.click();
+  }, [acceptedTypes]);
 
   const { error, onAttachmentChange } = useAttachmentChange({
     setAttachment,
@@ -101,41 +133,27 @@ export const MessageInput = ({
   });
 
   return (
-    <form className="flex items-center">
+    <form className="flex flex-col border border-gray-300 rounded-2xl m-4">
       <label htmlFor="chat" className="sr-only">
         {t("messages.message_field_prompt")}
       </label>
-      <PaperClipIcon
-        width={36}
-        className="mb-4 ml-4 cursor-pointer bg-gray-100 p-2 rounded-full"
-        onClick={onButtonClick}
-      />
       <input
         type="file"
         id="file"
         ref={inputFile}
         onChange={onAttachmentChange}
         aria-label={t("aria_labels.filepicker") || "File picker"}
+        accept={acceptedTypes?.join(",")}
         hidden
       />
       <div
         className={classNames(
-          "flex",
-          "items-center",
-          "max-h-300",
-          "mx-4 my-2 mb-6",
-          "bg-white",
-          "relative",
-          "no-scrollbar",
-          "z-10",
-          "p-1",
-          "w-full",
-          borderStyles,
+          "m-0 p-2",
+          attachment ? "border-b border-gray-200" : "",
         )}>
         {error ? (
           <p className="text-red-600 w-full m-1 ml-4">{error ? error : null}</p>
-        ) : !attachmentPreview ? (
-          //  Show regular text input if not in attachment view
+        ) : (
           <textarea
             autoFocus
             id="chat"
@@ -145,56 +163,81 @@ export const MessageInput = ({
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 if (value || attachment) {
-                  onSubmit?.(value);
-                  setValue("");
-                  setAttachment(undefined);
-                  setAttachmentPreview(undefined);
+                  if (attachment) {
+                    onSubmit?.(attachment, "attachment");
+                    setAttachment(undefined);
+                    setAttachmentPreview(undefined);
+                  }
+                  if (value) {
+                    onSubmit?.(value, "text");
+                    setValue("");
+                  }
                 }
               }
             }}
             ref={textAreaRef}
             rows={1}
-            className={textAreaStyles}
+            className={classNames(
+              textAreaStyles,
+              "border-b-8 border-gray-50 m-0 bg-transparent",
+            )}
             placeholder={t("messages.message_field_prompt") || ""}
             value={value}
-            disabled={isDisabled}
           />
-        ) : (
-          <div
-            // Bottom padding required to preserve aspect ratio
-            className="relative pb-[5%]">
-            {attachment?.mimeType.includes("video") ? (
-              <video width="320" height="240" controls autoPlay>
-                <source src={attachmentPreview} type="video/mp4" />
-                {t("attachments.video_messages_not_supported")}
-              </video>
-            ) : attachment?.mimeType.includes("application") ? (
-              <object
-                data={attachmentPreview}
-                type="application/pdf"
-                width="100%"
-                height="500px">
-                <p>{t("attachments.unable_to_display")}</p>
-                <a href={attachmentPreview}>
-                  {t("attachments.download_instead")}
-                </a>
-              </object>
-            ) : (
-              <img
-                src={attachmentPreview || ""}
-                alt={attachment?.filename}
-                className="relative w-95/100 min-h-[100px] max-h-80 rounded-xl overflow-auto"
-              />
-            )}
-
-            <XCircleIcon
-              width={20}
-              fill="gray"
-              className="absolute top-0 right-0 cursor-pointer"
-              onClick={() => setAttachmentPreview(undefined)}></XCircleIcon>
-          </div>
         )}
-        <div className="flex items-end absolute bottom-1.5 right-1">
+      </div>
+      {attachmentPreview && (
+        <div className="relative m-8 w-fit">
+          {attachment?.mimeType.includes("video") ? (
+            <video width="320" height="240" controls autoPlay>
+              <source src={attachmentPreview} type="video/mp4" />
+              {t("attachments.video_messages_not_supported")}
+            </video>
+          ) : attachment?.mimeType.includes("application") ? (
+            <object
+              data={attachmentPreview}
+              type="application/pdf"
+              width="100%"
+              height="500px">
+              <p>{t("attachments.unable_to_display")}</p>
+            </object>
+          ) : (
+            <img
+              src={attachmentPreview || ""}
+              alt={attachment?.filename}
+              className="relative w-95/100  max-h-80 rounded-xl overflow-auto"
+            />
+          )}
+
+          <XCircleIcon
+            width={20}
+            fill="black"
+            className="absolute -top-2 -right-2 cursor-pointer text-white"
+            onClick={() => setAttachmentPreview(undefined)}></XCircleIcon>
+        </div>
+      )}
+      <div className="flex justify-between bg-gray-100 rounded-b-2xl px-2">
+        <div className="flex flex-row">
+          <PhotographIcon
+            width={24}
+            height={24}
+            className="m-2 cursor-pointer text-gray-400 hover:text-black"
+            onClick={() => onButtonClick("image")}
+          />
+          <VideoCameraIcon
+            width={26}
+            height={26}
+            className="m-2 cursor-pointer text-gray-400 hover:text-black"
+            onClick={() => onButtonClick("video")}
+          />
+          <DocumentIcon
+            width={24}
+            height={24}
+            className="m-2 cursor-pointer text-gray-400 hover:text-black"
+            onClick={() => onButtonClick("application")}
+          />
+        </div>
+        <div className="flex items-center">
           <IconButton
             testId="message-input-submit"
             variant="secondary"
@@ -202,10 +245,15 @@ export const MessageInput = ({
             srText={t("aria_labels.submit_message") || ""}
             onClick={() => {
               if (value || attachment) {
-                onSubmit?.((value as string) || (attachment as Attachment));
-                setValue("");
-                setAttachment(undefined);
-                setAttachmentPreview(undefined);
+                if (attachment) {
+                  onSubmit?.(attachment, "attachment");
+                  setAttachment(undefined);
+                  setAttachmentPreview(undefined);
+                }
+                if (value) {
+                  onSubmit?.(value, "text");
+                  setValue("");
+                }
                 textAreaRef.current?.focus();
               }
             }}

--- a/src/component-library/components/MessageInput/MessageInput.tsx
+++ b/src/component-library/components/MessageInput/MessageInput.tsx
@@ -5,10 +5,7 @@ import { IconButton } from "../IconButton/IconButton";
 import { classNames } from "../../../../src/helpers";
 import { useTranslation } from "react-i18next";
 import { XCircleIcon } from "@heroicons/react/solid";
-import {
-  imageTypes,
-  useAttachmentChange,
-} from "../../../../src/hooks/useAttachmentChange";
+import { useAttachmentChange } from "../../../../src/hooks/useAttachmentChange";
 
 interface InputProps {
   /**
@@ -118,7 +115,6 @@ export const MessageInput = ({
         id="file"
         ref={inputFile}
         onChange={onAttachmentChange}
-        accept={imageTypes.join(", ")}
         aria-label={t("aria_labels.filepicker") || "File picker"}
         hidden
       />
@@ -167,10 +163,30 @@ export const MessageInput = ({
           <div
             // Bottom padding required to preserve aspect ratio
             className="relative pb-[5%]">
-            <img
-              src={attachmentPreview || ""}
-              alt={attachment?.filename}
-              className="relative w-95/100 min-h-[100px] max-h-80 rounded-xl overflow-auto"></img>
+            {attachment?.mimeType.includes("video") ? (
+              <video width="320" height="240" controls autoPlay>
+                <source src={attachmentPreview} type="video/mp4" />
+                {t("attachments.video_messages_not_supported")}
+              </video>
+            ) : attachment?.mimeType.includes("application") ? (
+              <object
+                data={attachmentPreview}
+                type="application/pdf"
+                width="100%"
+                height="500px">
+                <p>{t("attachments.unable_to_display")}</p>
+                <a href={attachmentPreview}>
+                  {t("attachments.download_instead")}
+                </a>
+              </object>
+            ) : (
+              <img
+                src={attachmentPreview || ""}
+                alt={attachment?.filename}
+                className="relative w-95/100 min-h-[100px] max-h-80 rounded-xl overflow-auto"
+              />
+            )}
+
             <XCircleIcon
               width={20}
               fill="gray"

--- a/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -130,7 +130,7 @@ const RemoteAttachmentMessageTile = ({
               width="100%"
               height="500px">
               <p>{t("attachments.unable_to_display")}</p>
-              <a href={url}>${t("attachments.download_instead")}</a>
+              <a href={url}>{t("attachments.download_instead")}</a>
             </object>
           ) : (
             <img

--- a/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -6,7 +6,10 @@ import {
 } from "xmtp-content-type-remote-attachment";
 import React from "react";
 import { useClient } from "@xmtp/react-sdk";
-import { humanFileSize } from "../../../../src/helpers/attachments";
+import {
+  getContentTypeFromFileName,
+  humanFileSize,
+} from "../../../../src/helpers/attachments";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 import { db } from "../../../helpers/attachment_db";
@@ -106,6 +109,8 @@ const RemoteAttachmentMessageTile = ({
       });
   }, []);
 
+  const contentType = getContentTypeFromFileName(content?.filename);
+
   return isError ? (
     <p className="text-red-600 p-0">{t("status_messaging.error_1_header")}</p>
   ) : (
@@ -113,11 +118,27 @@ const RemoteAttachmentMessageTile = ({
       {status === "loading" || isLoading ? t("status_messaging.loading") : ""}
       {url ? (
         <Zoom>
-          <img
-            src={url}
-            className="max-h-80 rounded-lg"
-            alt={content.filename}
-          />
+          {contentType === "video" ? (
+            <video controls autoPlay>
+              <source src={url} type="video/mp4" />
+              {t("attachments.video_messages_not_supported")}
+            </video>
+          ) : contentType === "application" ? (
+            <object
+              data={url}
+              type="application/pdf"
+              width="100%"
+              height="500px">
+              <p>{t("attachments.unable_to_display")}</p>
+              <a href={url}>${t("attachments.download_instead")}</a>
+            </object>
+          ) : (
+            <img
+              src={url}
+              className="max-h-80 rounded-lg"
+              alt={content.filename}
+            />
+          )}
         </Zoom>
       ) : null}
       {status !== "loaded" &&

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -1,3 +1,4 @@
+import { typeLookup } from "../hooks/useAttachmentChange";
 import { ATTACHMENT_ERRORS } from "./constants";
 
 /**
@@ -32,4 +33,18 @@ export const humanFileSize = (bytes: number, si = false, dp = 1) => {
   );
 
   return bytes.toFixed(dp) + " " + units[u];
+};
+
+/*
+ * Returns the content type of a file based on its filename extension.
+ *
+ */
+
+type contentTypes = "image" | "video" | "application" | undefined;
+
+export const getContentTypeFromFileName = (filename: string): contentTypes => {
+  const suffix = filename.split?.(".")?.pop();
+  if (suffix) {
+    return typeLookup[suffix] as contentTypes;
+  }
 };

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -40,11 +40,11 @@ export const humanFileSize = (bytes: number, si = false, dp = 1) => {
  *
  */
 
-type contentTypes = "image" | "video" | "application" | undefined;
+export type contentTypes = "image" | "video" | "application" | undefined;
 
 export const getContentTypeFromFileName = (filename: string): contentTypes => {
   const suffix = filename.split?.(".")?.pop();
   if (suffix) {
-    return typeLookup[suffix] as contentTypes;
+    return typeLookup[suffix];
   }
 };

--- a/src/helpers/tests/attachments.test.ts
+++ b/src/helpers/tests/attachments.test.ts
@@ -1,4 +1,4 @@
-import { humanFileSize } from "../attachments";
+import { getContentTypeFromFileName, humanFileSize } from "../attachments";
 import { ATTACHMENT_ERRORS } from "../constants";
 
 describe("humanFileSize", () => {
@@ -13,5 +13,27 @@ describe("humanFileSize", () => {
   });
   it("should throw an error if file is > 5 MB", () => {
     expect(humanFileSize(5000001)).toBe(ATTACHMENT_ERRORS.FILE_TOO_LARGE);
+  });
+});
+
+describe("getContentTypeFromFileName", () => {
+  test("should return image for .jpg extension", () => {
+    expect(getContentTypeFromFileName("file.jpg")).toEqual("image");
+  });
+
+  test("should return video for .mp4 extension", () => {
+    expect(getContentTypeFromFileName("video.mp4")).toEqual("video");
+  });
+
+  test("should return application for .pdf extension", () => {
+    expect(getContentTypeFromFileName("document.pdf")).toEqual("application");
+  });
+
+  test("should return undefined for no extension", () => {
+    expect(getContentTypeFromFileName("file")).toEqual(undefined);
+  });
+
+  test("should return undefined for invalid extension", () => {
+    expect(getContentTypeFromFileName("file.xyz")).toEqual(undefined);
   });
 });

--- a/src/hooks/useAttachmentChange.tsx
+++ b/src/hooks/useAttachmentChange.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback, useState } from "react";
 import { Attachment } from "xmtp-content-type-remote-attachment";
-import { humanFileSize } from "../helpers/attachments";
+import { contentTypes, humanFileSize } from "../helpers/attachments";
 import { ATTACHMENT_ERRORS } from "../helpers";
 import { useTranslation } from "react-i18next";
 
-export const typeLookup: Record<string, string> = {
+export const typeLookup: Record<string, contentTypes> = {
   jpg: "image",
   jpeg: "image",
   png: "image",
@@ -52,7 +52,10 @@ export const useAttachmentChange = ({
         const file = target.files[0];
 
         const [type, suffix] = file.type?.split?.("/");
-        if (!typeLookup[suffix] || typeLookup[suffix] !== file.type) {
+        if (
+          !typeLookup[suffix] ||
+          `${typeLookup[suffix]}/${suffix}` !== file.type
+        ) {
           setError(t("status_messaging.file_invalid_format"));
           setIsDragActive(false);
           return;
@@ -71,7 +74,7 @@ export const useAttachmentChange = ({
             return;
           }
 
-          const imageAttachment: Attachment = {
+          const attachment: Attachment = {
             filename: file.name,
             mimeType: file.type,
             data: new Uint8Array(data),
@@ -80,12 +83,12 @@ export const useAttachmentChange = ({
           setAttachmentPreview(
             URL.createObjectURL(
               new Blob([Buffer.from(data)], {
-                type: imageAttachment.mimeType,
+                type: attachment.mimeType,
               }),
             ),
           );
 
-          setAttachment(imageAttachment);
+          setAttachment(attachment);
         });
 
         fileReader.readAsArrayBuffer(file);

--- a/src/hooks/useAttachmentChange.tsx
+++ b/src/hooks/useAttachmentChange.tsx
@@ -4,13 +4,18 @@ import { humanFileSize } from "../helpers/attachments";
 import { ATTACHMENT_ERRORS } from "../helpers";
 import { useTranslation } from "react-i18next";
 
-export const imageTypes = [
-  "image/jpg",
-  "image/jpeg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-];
+export const typeLookup: Record<string, string> = {
+  jpg: "image",
+  jpeg: "image",
+  png: "image",
+  gif: "image",
+  webp: "image",
+  quicktime: "video",
+  mov: "video",
+  mp4: "video",
+  pdf: "application",
+  doc: "application",
+};
 
 interface useAttachmentChangeProps {
   setAttachment: (attachment: Attachment | undefined) => void;
@@ -46,8 +51,8 @@ export const useAttachmentChange = ({
       if (target?.files?.length && setAttachment) {
         const file = target.files[0];
 
-        // Currently images are the only attachment type supported
-        if (!imageTypes.includes(file.type)) {
+        const [type, suffix] = file.type?.split?.("/");
+        if (!typeLookup[suffix] || typeLookup[suffix] !== file.type) {
           setError(t("status_messaging.file_invalid_format"));
           setIsDragActive(false);
           return;

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -38,8 +38,8 @@ const useSendMessage = (conversationId: address, attachment?: Attachment) => {
   const setConversations = useXmtpStore((state) => state.setConversations);
 
   const sendMessage = useCallback(
-    async (message: string | Attachment) => {
-      if (attachment) {
+    async (message: string | Attachment, type: "text" | "attachment") => {
+      if (attachment && type === "attachment") {
         const web3Storage = new Web3Storage({
           token: import.meta.env.VITE_WEB3_STORAGE_TOKEN as string,
         });

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -42,6 +42,11 @@
     "message_field_prompt": "Write a message",
     "conversation_start": "This is the beginning of the conversation"
   },
+  "attachments": {
+    "unable_to_display": "Unable to display attachment.",
+    "download_instead": "Download instead.",
+    "video_messages_not_supported": "Your browser does not support the video tag."
+  },
   "menu": {
     "collapse_header": "Collapse",
     "gallery_header": "Gallery",


### PR DESCRIPTION
This PR is broken down into 2 commits:

1) Initial setup to be able to add documents and videos within our current design. 
2) Updating the message input to show this in a more visually appealing way. 