### PR TITLE
Updated avatar and link fixes

### DIFF
--- a/src/component-library/components/Avatar/Avatar.tsx
+++ b/src/component-library/components/Avatar/Avatar.tsx
@@ -30,7 +30,7 @@ export const Avatar = ({ url, isLoading, address }: AvatarProps) => {
       <>
         <img
           data-testid="avatar"
-          className="w-[40px] h-[40px] rounded-full"
+          className="min-w-[40px] max-w-[40px] h-[40px] rounded-full"
           src={url}
           alt={address}
         />

--- a/src/controllers/MessageContentController.tsx
+++ b/src/controllers/MessageContentController.tsx
@@ -32,7 +32,7 @@ const MessageContentController = ({
         escapeHtml
         onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
         matchers={[
-          new UrlMatcher("url", { validateTLD: false }),
+          new UrlMatcher("url"),
           new EmojiMatcher("emoji", {
             convertEmoticon: true,
             convertShortcode: true,


### PR DESCRIPTION
This PR includes 2 small fixes for the following:

- The Interweave library we use for rendering message content had `{validateTLD: false}` set, which disables top-level domain validation for URLs. This means URLs with invalid TLDs (like .example) were rendered as links. This PR fixes that and closes #280 
- `min-width` needed to be specified to close out #283 