### PR TITLE
Attachment fixes

### DIFF
--- a/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
+++ b/src/component-library/components/RemoteAttachmentMessageTile/RemoteAttachmentMessageTile.tsx
@@ -95,10 +95,12 @@ const RemoteAttachmentMessageTile = ({
 
   const load = (inCache = false, clickedToLoad = false) => {
     // If attachment is not in cache and it is the appropriate file size,
-    // or it's too large and user has initiated this anyway, run handleLoading
+    // or it's too large and user has initiated this anyway,
+    // or if it's an outgoing message, run handleLoading
     const loadImage =
       clickedToLoad === true ||
-      (!inCache && fileSize !== ATTACHMENT_ERRORS.FILE_TOO_LARGE);
+      (!inCache && fileSize !== ATTACHMENT_ERRORS.FILE_TOO_LARGE) ||
+      isSelf;
     if (loadImage) {
       setStatus("loadRequested");
     }

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -57,6 +57,6 @@ export const humanFileSize = (bytes: number, si = false, dp = 1) => {
 export type contentTypes = "image" | "video" | "application" | undefined;
 
 export const getContentTypeFromFileName = (filename: string): contentTypes => {
-  const suffix = filename.split?.(".")?.pop();
+  const suffix = filename.split?.(".")?.pop()?.toLowerCase();
   return suffix ? typeLookup[suffix] : undefined;
 };

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -22,8 +22,8 @@ export const typeLookup: Record<string, contentTypes> = {
  * @returns The human readable file size string.
  */
 export const humanFileSize = (bytes: number, si = false, dp = 1) => {
-  // Throws error if > 5 MB
-  if (bytes > 5000000) {
+  // Throws error if > 10 MB
+  if (bytes > 10000000) {
     return ATTACHMENT_ERRORS.FILE_TOO_LARGE;
   }
   const thresh = si ? 1000 : 1024;

--- a/src/helpers/tests/attachments.test.ts
+++ b/src/helpers/tests/attachments.test.ts
@@ -22,6 +22,10 @@ describe("getContentTypeFromFileName", () => {
     expect(getContentTypeFromFileName("file.jpg")).toEqual("image");
   });
 
+  test("should return image for .JPG extension", () => {
+    expect(getContentTypeFromFileName("file.JPG")).toEqual("image");
+  });
+
   test("should return video for .mp4 extension", () => {
     expect(getContentTypeFromFileName("video.mp4")).toEqual("video");
   });

--- a/src/helpers/tests/attachments.test.ts
+++ b/src/helpers/tests/attachments.test.ts
@@ -12,8 +12,8 @@ describe("humanFileSize", () => {
   it("should return '1 MB' for 1048576 bytes", () => {
     expect(humanFileSize(1048576)).toBe("1.0 MB");
   });
-  it("should throw an error if file is > 5 MB", () => {
-    expect(humanFileSize(5000001)).toBe(ATTACHMENT_ERRORS.FILE_TOO_LARGE);
+  it("should throw an error if file is > 10 MB", () => {
+    expect(humanFileSize(10000001)).toBe(ATTACHMENT_ERRORS.FILE_TOO_LARGE);
   });
 });
 

--- a/src/hooks/useAttachmentChange.tsx
+++ b/src/hooks/useAttachmentChange.tsx
@@ -36,7 +36,7 @@ export const useAttachmentChange = ({
       if (target?.files?.length && setAttachment) {
         const file = target.files[0];
 
-        // Displays error if > 5 MB
+        // Displays error if > 10 MB
         if (humanFileSize(file.size) === ATTACHMENT_ERRORS.FILE_TOO_LARGE) {
           setAttachmentError(t("status_messaging.file_too_large"));
           setIsDragActive(false);


### PR DESCRIPTION
Fixes a couple of issues with attachments:

- Messages initiated from Converse were showing up as blank; that was due to them being slightly over the file size we support and the "file too large" logic only showing for received messages. Now, we auto-load all sent messages even if over the size limit, and bumped the size limit of images sent from this app or auto-loaded received images to 10MB.

- Also fixed an issue discovered in the process to remove case sensitivity of extensions.