### PR TITLE
Bumped RainbowKit version for WC v2 support

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,3 +21,4 @@ jobs:
           start: npm run dev
         env:
           INFURA_ID: ${{ secrets.INFURA_ID }}
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,5 +20,4 @@ jobs:
           build: npm run build
           start: npm run dev
         env:
-          INFURA_ID: ${{ secrets.INFURA_ID }}
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          VITE_PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@datadog/browser-rum": "^4.38.0",
         "@headlessui/react": "^1.4.3",
         "@heroicons/react": "^1.0.5",
-        "@rainbow-me/rainbowkit": "^0.12.8",
+        "@rainbow-me/rainbowkit": "^0.12.15",
         "@typescript-eslint/parser": "^5.59.9",
         "@vitejs/plugin-react": "^4.0.0",
         "@wagmi/core": "^0.10.11",
@@ -2589,9 +2589,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -2684,9 +2684,9 @@
       "dev": true
     },
     "node_modules/@coinbase/wallet-sdk": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.6.6.tgz",
-      "integrity": "sha512-vX+epj/Ttjo7XRwlr3TFUUfW5GTRMvORpERPwiu7z2jl3DSVL4rXLmHt5y6LDPlUVreas2gumdcFbu0fLRG9Jg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz",
+      "integrity": "sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==",
       "dependencies": {
         "@metamask/safe-event-emitter": "2.0.0",
         "@solana/web3.js": "^1.70.1",
@@ -2716,9 +2716,9 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/preact": {
-      "version": "10.15.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.0.tgz",
-      "integrity": "sha512-nZSa8M2R2m1n7nJSBlzDpxRJaIsejrTO1vlFbdpFvyC8qM1iU+On2y0otfoUm6SRB5o0lF0CKDFxg6grEFU0iQ==",
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4565,57 +4565,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
-    "node_modules/@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/provider/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
@@ -4623,9 +4572,9 @@
       "dev": true
     },
     "node_modules/@ledgerhq/connect-kit-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
-      "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.0.tgz",
+      "integrity": "sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",
@@ -4633,9 +4582,9 @@
       "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
+      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
@@ -4688,9 +4637,9 @@
       }
     },
     "node_modules/@metamask/utils/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4811,17 +4760,14 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
       "dependencies": {
-        "@noble/hashes": "1.3.0"
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/ed25519": {
@@ -4836,15 +4782,15 @@
       ]
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/secp256k1": {
       "version": "1.7.1",
@@ -4888,11 +4834,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4959,9 +4900,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rainbow-me/rainbowkit": {
-      "version": "0.12.14",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.14.tgz",
-      "integrity": "sha512-G7/uYl6TrDS7eiQauc5GEWQ09wCV91hs7xZqj3Af1wsLmbnJM2paUEMs0NI4rbvw0yiMkfoNYMZ2Wfl7NQLKaA==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.17.tgz",
+      "integrity": "sha512-H5JT1caMTcAmjMTAYG9rDhZdNeNkfEwwYSbI/x+xfXaeQNqFeSePKHwl2jbrDiTlXWToxxT0AC2lp1b/4t0J9w==",
       "dependencies": {
         "@vanilla-extract/css": "1.9.1",
         "@vanilla-extract/dynamic": "2.0.2",
@@ -4977,7 +4918,7 @@
         "ethers": ">=5.6.8",
         "react": ">=17",
         "react-dom": ">=17",
-        "wagmi": "0.12.x"
+        "wagmi": ">=0.12.18 <1.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -5173,11 +5114,11 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.0.tgz",
-      "integrity": "sha512-APV5ru9vsWSvIPEmL6YmF20cJexcoZXRQOkKSXoKFK2yoyxMiTfAUDSxuwou3WInLzjsuh9hveWE4q2iexgpOg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.78.0.tgz",
+      "integrity": "sha512-CSjCjo+RELJ5puoZALfznN5EF0YvL1V8NQrQYovsdjE1lCV6SqbKAIZD0+9LlqCBoa1ibuUaR7G2SooYzvzmug==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": "^7.22.3",
         "@noble/curves": "^1.0.0",
         "@noble/hashes": "^1.3.0",
         "@solana/buffer-layout": "^4.0.0",
@@ -5188,8 +5129,8 @@
         "bs58": "^4.0.1",
         "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
-        "jayson": "^3.4.4",
-        "node-fetch": "^2.6.7",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.6.11",
         "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
       }
@@ -12594,9 +12535,9 @@
       }
     },
     "node_modules/@wagmi/connectors": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.19.tgz",
-      "integrity": "sha512-1EnVdNjP5dAfWoW8dlUDZS+Lva8MYabWK+vwzSUBeSyJcAslXInoiHLb+cz9p8oAAqXspcPLRX3XPErYav23gA==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.24.tgz",
+      "integrity": "sha512-1pI0G9HRblc651dCz9LXuEu/zWQk23XwOUYqJEINb/c2TTLtw5TnTRIcefxxK6RnxeJvcKfnmK0rdZp/4ujFAA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -12612,9 +12553,9 @@
         "@ledgerhq/connect-kit-loader": "^1.0.1",
         "@safe-global/safe-apps-provider": "^0.15.2",
         "@safe-global/safe-apps-sdk": "^7.9.0",
-        "@walletconnect/ethereum-provider": "2.7.2",
+        "@walletconnect/ethereum-provider": "2.9.0",
         "@walletconnect/legacy-provider": "^2.0.0",
-        "@web3modal/standalone": "^2.3.7",
+        "@walletconnect/modal": "^2.5.9",
         "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7"
       },
@@ -12633,9 +12574,9 @@
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.11.tgz",
-      "integrity": "sha512-WOmG2RG65U6i+p09/aFztFSLPCeC+CYnkPh+OXrxQ8Q3m829983sH7xUTRbFAl561lRevUHmB+XS/na+Oj2bYQ==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.17.tgz",
+      "integrity": "sha512-qud45y3IlHp7gYWzoFeyysmhyokRie59Xa5tcx5F1E/v4moD5BY0kzD26mZW/ZQ3WZuVK/lZwiiPRqpqWH52Gw==",
       "funding": [
         {
           "type": "gitcoin",
@@ -12648,7 +12589,7 @@
       ],
       "dependencies": {
         "@wagmi/chains": "0.2.22",
-        "@wagmi/connectors": "0.3.19",
+        "@wagmi/connectors": "0.3.24",
         "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7",
         "zustand": "^4.3.1"
@@ -12747,25 +12688,25 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.7.2.tgz",
-      "integrity": "sha512-bvmutLrKKLlQ1WxKCvvX5p5YVox1D1f3Enp6hzAiZf4taN+n/M5rmwfAcLgLhp4cTAUDhl3zgtZErzDyJnvGvQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.9.0.tgz",
+      "integrity": "sha512-rSXkC0SXMigJRdIi/M2RMuEuATY1AwtlTWQBnqyxoht7xbO2bQNPCXn0XL4s/GRNrSUtoKSY4aPMHXV4W4yLBA==",
       "dependencies": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/sign-client": "2.7.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/universal-provider": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "^1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/universal-provider": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       },
       "peerDependencies": {
-        "@web3modal/standalone": ">=2"
+        "@walletconnect/modal": ">=2"
       },
       "peerDependenciesMeta": {
-        "@web3modal/standalone": {
+        "@walletconnect/modal": {
           "optional": true
         }
       }
@@ -12779,33 +12720,32 @@
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/types": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-      "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/utils": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-      "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
+        "@walletconnect/types": "2.9.0",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -12986,9 +12926,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.11.tgz",
-      "integrity": "sha512-TiFJ6saasKXD+PwGkm5ZGSw0837nc6EeFmurSPgIT/NofnOV4Tv7CVJqGQN0rQYoJUSYu21cwHNYaFkzNpUN+w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -13120,98 +13060,10 @@
         "qrcode": "^1.5.1"
       }
     },
-    "node_modules/@walletconnect/legacy-modal/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@walletconnect/legacy-modal/node_modules/preact": {
-      "version": "10.15.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.0.tgz",
-      "integrity": "sha512-nZSa8M2R2m1n7nJSBlzDpxRJaIsejrTO1vlFbdpFvyC8qM1iU+On2y0otfoUm6SRB5o0lF0CKDFxg6grEFU0iQ==",
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -13232,57 +13084,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@walletconnect/legacy-provider": {
@@ -13376,6 +13177,51 @@
       "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==",
       "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry",
       "dev": true
+    },
+    "node_modules/@walletconnect/modal": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.0.tgz",
+      "integrity": "sha512-hV8pfWvUDjanxfXZ7DouyboM+LOcSsJBX3cMsDyNwe0f19W/yIZTUQz9k4DkuIGjEQSUO9zfEX+BAYAeP27uag==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.6.0",
+        "@walletconnect/modal-ui": "2.6.0"
+      }
+    },
+    "node_modules/@walletconnect/modal-core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.0.tgz",
+      "integrity": "sha512-95315iaiVlz72W8IWd0gvBGHenS9cbLXwURjbN6wm12KSc6zbQA6u2RO0SRlcwc+dQcNzhwB/ce7TZYLQUVMfw==",
+      "dependencies": {
+        "valtio": "1.10.7"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.0.tgz",
+      "integrity": "sha512-A9Eohricm+VYTiUELVfum7AjyhxquWqy8ZhyVWXfm2ucpHnG0lhiY2mdLrqoE9EEW/ql4tmfYltX2ZD9wzTu9A==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.6.0",
+        "lit": "2.7.6",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui/node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/@walletconnect/qrcode-modal": {
       "version": "1.8.0",
@@ -13679,38 +13525,39 @@
       "dev": true
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.7.2.tgz",
-      "integrity": "sha512-JOYPmrgR4YG4M2comNcXaa8cLIws0ZJj/SCpF0XJzRZP2+OXWouK19UaI32ROQrcwNodBNeYFRfT5hSM5xjfKg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.0.tgz",
+      "integrity": "sha512-mEKc4LlLMebCe45qzqh+MX4ilQK4kOEBzLY6YJpG8EhyT45eX4JMNA7qQoYa9MRMaaVb/7USJcc4e3ZrjZvQmA==",
       "dependencies": {
-        "@walletconnect/core": "2.7.2",
+        "@walletconnect/core": "2.9.0",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/core": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.2.tgz",
-      "integrity": "sha512-gInSwh3uLpTEkDGArfOFoOVgiXW+zkZJpGqfARVi5fhSxsnL1jYNpqO2k8KAXUPfB4MIzLyaGruiaywncLAczA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-provider": "^1.0.12",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -13725,33 +13572,32 @@
       }
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-      "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/utils": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-      "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
+        "@walletconnect/types": "2.9.0",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -13856,19 +13702,18 @@
       "dev": true
     },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.7.2.tgz",
-      "integrity": "sha512-5glu7vCmq3SFUYgniICf7CUZMwrd6FNS/qnCjrnfgW8T55Opms9YkhRpWTJFHpBdNRWF7n6z/Kss2J8olKTxKw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.9.0.tgz",
+      "integrity": "sha512-k3nkSBkF69sJJVoe17IVoPtnhp/sgaa2t+x7BvA/BKeMxE0DGdtRJdEXotTc8DBmI7o2tkq6l8+HyFBGjQ/CjQ==",
       "dependencies": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.7.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
-        "eip1193-provider": "1.0.1",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       }
     },
@@ -13881,33 +13726,32 @@
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-      "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-      "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
+        "@walletconnect/types": "2.9.0",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -14060,191 +13904,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/parse-link-header/-/parse-link-header-3.1.0.tgz",
       "integrity": "sha512-K1undnK70vLLauqdE8bq/l98isTF2FDhcP0UPpXVSjkSWe3xhAn5eRXk5jfA1E5ycNm84Ws/rQFUD7ue11nciw=="
-    },
-    "node_modules/@web3modal/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-v6Y/eQJSI2YfUTv8rGqjFabqdk3ZPjx6Fe7j5Q8fw0ZWF1YRGM3mySG457qtKQ7D7E1kNKA3BHbaOZ3pgQoG6A==",
-      "dependencies": {
-        "buffer": "6.0.3",
-        "valtio": "1.10.5"
-      }
-    },
-    "node_modules/@web3modal/standalone": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.4.1.tgz",
-      "integrity": "sha512-ZrI5LwWeT9sd8A3FdIX/gBp3ZrzrX882Ln1vJN0LTCmeP2OUsYcW5bPxjv1PcJ1YUBY7Tg4aTgMUnAVTTuqb+w==",
-      "dependencies": {
-        "@web3modal/core": "2.4.1",
-        "@web3modal/ui": "2.4.1"
-      }
-    },
-    "node_modules/@web3modal/ui": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.4.1.tgz",
-      "integrity": "sha512-x1ceyd3mMJsIHs5UUTLvE+6qyCjhyjL6gB/wVmTDbwASHSQIVyshQJ+s7BwIEMP/pbAsYDg+/M8EiUuE+/E/kg==",
-      "dependencies": {
-        "@web3modal/core": "2.4.1",
-        "lit": "2.7.4",
-        "motion": "10.15.5",
-        "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@web3modal/ui/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/qrcode": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
-      "dependencies": {
-        "dijkstrajs": "^1.0.1",
-        "encode-utf8": "^1.0.3",
-        "pngjs": "^5.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/@web3modal/ui/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -15415,14 +15074,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -16712,6 +16363,59 @@
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-2.6.2.tgz",
       "integrity": "sha512-0tOHJNMF9+4R3qcbBL+4IxLErpaYSYvzs10aXuECDbZdJOuJHdagJMAqvLdeaUQTI/o2uSCDRpet6ywDiKOAYw==",
       "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/clone": {
       "version": "2.1.2",
@@ -18172,14 +17876,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
-    },
-    "node_modules/eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "dependencies": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "node_modules/ejs": {
       "version": "3.1.9",
@@ -20513,6 +20209,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -22878,9 +22575,9 @@
       }
     },
     "node_modules/jayson": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
-      "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
+      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -22892,7 +22589,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -24004,9 +23700,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.4.tgz",
-      "integrity": "sha512-cgD7xrZoYr21mbrkZIuIrj98YTMw/snJPg52deWVV4A8icLyNHI3bF70xsJeAgwTuiq5Kkd+ZR8gybSJDCPB7g==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
+      "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -24024,9 +23720,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.4.tgz",
-      "integrity": "sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.5.tgz",
+      "integrity": "sha512-YqUzpisJodwKIlbMFCtyrp58oLloKGnnPLMJ1t23cbfIJjg/H9pvLWK4XS69YeubK5HUs1UE4ys9w5dP1zg6IA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -24084,7 +23780,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clone": {
       "version": "4.5.0",
@@ -25023,16 +24720,16 @@
       }
     },
     "node_modules/motion": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-10.15.5.tgz",
-      "integrity": "sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
       "dependencies": {
         "@motionone/animation": "^10.15.1",
-        "@motionone/dom": "^10.15.5",
-        "@motionone/svelte": "^10.15.5",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
-        "@motionone/vue": "^10.15.5"
+        "@motionone/vue": "^10.16.2"
       }
     },
     "node_modules/move-file": {
@@ -27154,145 +26851,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
       "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
-    },
-    "node_modules/qrcode/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/qrcode/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/qrcode/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/qrcode/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/qs": {
       "version": "6.11.2",
@@ -30723,9 +30281,9 @@
       }
     },
     "node_modules/valtio": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.5.tgz",
-      "integrity": "sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.7.tgz",
+      "integrity": "sha512-XUwXJ9twXqwfVhXlcbYlCcRUUSOmp8RcJODVAxPrUZc2jh3com13B49MOL/cbgcTOX+5yf7wdMqbFGR7ba2sPg==",
       "dependencies": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -30998,9 +30556,9 @@
       }
     },
     "node_modules/wagmi": {
-      "version": "0.12.13",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.13.tgz",
-      "integrity": "sha512-1J+F68MztodPUo2OIFImiC3OoZD4gdryxTidfwQz9LJawXdBNmAOFvq0LQClrrqgFk0Gd3EoLo/MKGiEn2RsMg==",
+      "version": "0.12.19",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.19.tgz",
+      "integrity": "sha512-S/el9BDb/HNeQWh1v8TvntMPX/CgKLDAoJqDb8i7jifLfWPqFL7gor3vnI1Vs6ZlB8uh7m+K1Qyg+mKhbITuDQ==",
       "funding": [
         {
           "type": "gitcoin",
@@ -31015,7 +30573,7 @@
         "@tanstack/query-sync-storage-persister": "^4.27.1",
         "@tanstack/react-query": "^4.28.0",
         "@tanstack/react-query-persist-client": "^4.28.0",
-        "@wagmi/core": "0.10.11",
+        "@wagmi/core": "0.10.17",
         "abitype": "^0.3.0",
         "use-sync-external-store": "^1.2.0"
       },
@@ -31918,12 +31476,98 @@
         "node": ">= 14"
       }
     },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yauzl": {
@@ -33755,9 +33399,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -33831,9 +33475,9 @@
       "dev": true
     },
     "@coinbase/wallet-sdk": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.6.6.tgz",
-      "integrity": "sha512-vX+epj/Ttjo7XRwlr3TFUUfW5GTRMvORpERPwiu7z2jl3DSVL4rXLmHt5y6LDPlUVreas2gumdcFbu0fLRG9Jg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz",
+      "integrity": "sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==",
       "requires": {
         "@metamask/safe-event-emitter": "2.0.0",
         "@solana/web3.js": "^1.70.1",
@@ -33860,9 +33504,9 @@
           "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "preact": {
-          "version": "10.15.0",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.0.tgz",
-          "integrity": "sha512-nZSa8M2R2m1n7nJSBlzDpxRJaIsejrTO1vlFbdpFvyC8qM1iU+On2y0otfoUm6SRB5o0lF0CKDFxg6grEFU0iQ=="
+          "version": "10.16.0",
+          "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+          "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA=="
         },
         "rxjs": {
           "version": "6.6.7",
@@ -35018,42 +34662,6 @@
         }
       }
     },
-    "@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "requires": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "requires": {}
-        }
-      }
-    },
-    "@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "requires": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "requires": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "@juggle/resize-observer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
@@ -35061,9 +34669,9 @@
       "dev": true
     },
     "@ledgerhq/connect-kit-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
-      "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.0.tgz",
+      "integrity": "sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg=="
     },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",
@@ -35071,9 +34679,9 @@
       "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
     },
     "@lit/reactive-element": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
+      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
       "requires": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
@@ -35113,9 +34721,9 @@
           }
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -35229,11 +34837,11 @@
       }
     },
     "@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
       "requires": {
-        "@noble/hashes": "1.3.0"
+        "@noble/hashes": "1.3.1"
       }
     },
     "@noble/ed25519": {
@@ -35242,9 +34850,9 @@
       "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
     },
     "@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
     },
     "@noble/secp256k1": {
       "version": "1.7.1",
@@ -35273,11 +34881,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -35341,9 +34944,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@rainbow-me/rainbowkit": {
-      "version": "0.12.14",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.14.tgz",
-      "integrity": "sha512-G7/uYl6TrDS7eiQauc5GEWQ09wCV91hs7xZqj3Af1wsLmbnJM2paUEMs0NI4rbvw0yiMkfoNYMZ2Wfl7NQLKaA==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.17.tgz",
+      "integrity": "sha512-H5JT1caMTcAmjMTAYG9rDhZdNeNkfEwwYSbI/x+xfXaeQNqFeSePKHwl2jbrDiTlXWToxxT0AC2lp1b/4t0J9w==",
       "requires": {
         "@vanilla-extract/css": "1.9.1",
         "@vanilla-extract/dynamic": "2.0.2",
@@ -35523,11 +35126,11 @@
       }
     },
     "@solana/web3.js": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.0.tgz",
-      "integrity": "sha512-APV5ru9vsWSvIPEmL6YmF20cJexcoZXRQOkKSXoKFK2yoyxMiTfAUDSxuwou3WInLzjsuh9hveWE4q2iexgpOg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.78.0.tgz",
+      "integrity": "sha512-CSjCjo+RELJ5puoZALfznN5EF0YvL1V8NQrQYovsdjE1lCV6SqbKAIZD0+9LlqCBoa1ibuUaR7G2SooYzvzmug==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": "^7.22.3",
         "@noble/curves": "^1.0.0",
         "@noble/hashes": "^1.3.0",
         "@solana/buffer-layout": "^4.0.0",
@@ -35538,8 +35141,8 @@
         "bs58": "^4.0.1",
         "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
-        "jayson": "^3.4.4",
-        "node-fetch": "^2.6.7",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.6.11",
         "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
       },
@@ -41083,28 +40686,28 @@
       "requires": {}
     },
     "@wagmi/connectors": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.19.tgz",
-      "integrity": "sha512-1EnVdNjP5dAfWoW8dlUDZS+Lva8MYabWK+vwzSUBeSyJcAslXInoiHLb+cz9p8oAAqXspcPLRX3XPErYav23gA==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.24.tgz",
+      "integrity": "sha512-1pI0G9HRblc651dCz9LXuEu/zWQk23XwOUYqJEINb/c2TTLtw5TnTRIcefxxK6RnxeJvcKfnmK0rdZp/4ujFAA==",
       "requires": {
         "@coinbase/wallet-sdk": "^3.6.6",
         "@ledgerhq/connect-kit-loader": "^1.0.1",
         "@safe-global/safe-apps-provider": "^0.15.2",
         "@safe-global/safe-apps-sdk": "^7.9.0",
-        "@walletconnect/ethereum-provider": "2.7.2",
+        "@walletconnect/ethereum-provider": "2.9.0",
         "@walletconnect/legacy-provider": "^2.0.0",
-        "@web3modal/standalone": "^2.3.7",
+        "@walletconnect/modal": "^2.5.9",
         "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7"
       }
     },
     "@wagmi/core": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.11.tgz",
-      "integrity": "sha512-WOmG2RG65U6i+p09/aFztFSLPCeC+CYnkPh+OXrxQ8Q3m829983sH7xUTRbFAl561lRevUHmB+XS/na+Oj2bYQ==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.17.tgz",
+      "integrity": "sha512-qud45y3IlHp7gYWzoFeyysmhyokRie59Xa5tcx5F1E/v4moD5BY0kzD26mZW/ZQ3WZuVK/lZwiiPRqpqWH52Gw==",
       "requires": {
         "@wagmi/chains": "0.2.22",
-        "@wagmi/connectors": "0.3.19",
+        "@wagmi/connectors": "0.3.24",
         "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7",
         "zustand": "^4.3.1"
@@ -41199,18 +40802,18 @@
       }
     },
     "@walletconnect/ethereum-provider": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.7.2.tgz",
-      "integrity": "sha512-bvmutLrKKLlQ1WxKCvvX5p5YVox1D1f3Enp6hzAiZf4taN+n/M5rmwfAcLgLhp4cTAUDhl3zgtZErzDyJnvGvQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.9.0.tgz",
+      "integrity": "sha512-rSXkC0SXMigJRdIi/M2RMuEuATY1AwtlTWQBnqyxoht7xbO2bQNPCXn0XL4s/GRNrSUtoKSY4aPMHXV4W4yLBA==",
       "requires": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/sign-client": "2.7.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/universal-provider": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "^1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/universal-provider": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       },
       "dependencies": {
@@ -41223,33 +40826,32 @@
           }
         },
         "@walletconnect/types": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-          "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+          "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
           "requires": {
             "@walletconnect/events": "^1.0.1",
             "@walletconnect/heartbeat": "1.2.1",
-            "@walletconnect/jsonrpc-types": "^1.0.2",
+            "@walletconnect/jsonrpc-types": "1.0.3",
             "@walletconnect/keyvaluestorage": "^1.0.2",
             "@walletconnect/logger": "^2.0.1",
             "events": "^3.3.0"
           }
         },
         "@walletconnect/utils": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-          "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+          "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
           "requires": {
             "@stablelib/chacha20poly1305": "1.0.1",
             "@stablelib/hkdf": "1.0.1",
             "@stablelib/random": "^1.0.2",
             "@stablelib/sha256": "1.0.1",
             "@stablelib/x25519": "^1.0.3",
-            "@walletconnect/jsonrpc-utils": "^1.0.7",
             "@walletconnect/relay-api": "^1.0.9",
             "@walletconnect/safe-json": "^1.0.2",
             "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.7.2",
+            "@walletconnect/types": "2.9.0",
             "@walletconnect/window-getters": "^1.0.1",
             "@walletconnect/window-metadata": "^1.0.1",
             "detect-browser": "5.3.0",
@@ -41438,9 +41040,9 @@
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.11.tgz",
-      "integrity": "sha512-TiFJ6saasKXD+PwGkm5ZGSw0837nc6EeFmurSPgIT/NofnOV4Tv7CVJqGQN0rQYoJUSYu21cwHNYaFkzNpUN+w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "requires": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -41552,74 +41154,10 @@
         "qrcode": "^1.5.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "preact": {
-          "version": "10.15.0",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.0.tgz",
-          "integrity": "sha512-nZSa8M2R2m1n7nJSBlzDpxRJaIsejrTO1vlFbdpFvyC8qM1iU+On2y0otfoUm6SRB5o0lF0CKDFxg6grEFU0iQ=="
+          "version": "10.16.0",
+          "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+          "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA=="
         },
         "qrcode": {
           "version": "1.5.3",
@@ -41630,48 +41168,6 @@
             "encode-utf8": "^1.0.3",
             "pngjs": "^5.0.0",
             "yargs": "^15.3.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
           }
         }
       }
@@ -41770,6 +41266,47 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
       "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==",
       "dev": true
+    },
+    "@walletconnect/modal": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.0.tgz",
+      "integrity": "sha512-hV8pfWvUDjanxfXZ7DouyboM+LOcSsJBX3cMsDyNwe0f19W/yIZTUQz9k4DkuIGjEQSUO9zfEX+BAYAeP27uag==",
+      "requires": {
+        "@walletconnect/modal-core": "2.6.0",
+        "@walletconnect/modal-ui": "2.6.0"
+      }
+    },
+    "@walletconnect/modal-core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.0.tgz",
+      "integrity": "sha512-95315iaiVlz72W8IWd0gvBGHenS9cbLXwURjbN6wm12KSc6zbQA6u2RO0SRlcwc+dQcNzhwB/ce7TZYLQUVMfw==",
+      "requires": {
+        "valtio": "1.10.7"
+      }
+    },
+    "@walletconnect/modal-ui": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.0.tgz",
+      "integrity": "sha512-A9Eohricm+VYTiUELVfum7AjyhxquWqy8ZhyVWXfm2ucpHnG0lhiY2mdLrqoE9EEW/ql4tmfYltX2ZD9wzTu9A==",
+      "requires": {
+        "@walletconnect/modal-core": "2.6.0",
+        "lit": "2.7.6",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
+      },
+      "dependencies": {
+        "qrcode": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+          "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+          "requires": {
+            "dijkstrajs": "^1.0.1",
+            "encode-utf8": "^1.0.3",
+            "pngjs": "^5.0.0",
+            "yargs": "^15.3.1"
+          }
+        }
+      }
     },
     "@walletconnect/qrcode-modal": {
       "version": "1.8.0",
@@ -42024,38 +41561,39 @@
       "dev": true
     },
     "@walletconnect/sign-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.7.2.tgz",
-      "integrity": "sha512-JOYPmrgR4YG4M2comNcXaa8cLIws0ZJj/SCpF0XJzRZP2+OXWouK19UaI32ROQrcwNodBNeYFRfT5hSM5xjfKg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.0.tgz",
+      "integrity": "sha512-mEKc4LlLMebCe45qzqh+MX4ilQK4kOEBzLY6YJpG8EhyT45eX4JMNA7qQoYa9MRMaaVb/7USJcc4e3ZrjZvQmA==",
       "requires": {
-        "@walletconnect/core": "2.7.2",
+        "@walletconnect/core": "2.9.0",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       },
       "dependencies": {
         "@walletconnect/core": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.2.tgz",
-          "integrity": "sha512-gInSwh3uLpTEkDGArfOFoOVgiXW+zkZJpGqfARVi5fhSxsnL1jYNpqO2k8KAXUPfB4MIzLyaGruiaywncLAczA==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+          "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
           "requires": {
             "@walletconnect/heartbeat": "1.2.1",
-            "@walletconnect/jsonrpc-provider": "^1.0.12",
-            "@walletconnect/jsonrpc-utils": "^1.0.7",
-            "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+            "@walletconnect/jsonrpc-provider": "1.0.13",
+            "@walletconnect/jsonrpc-types": "1.0.3",
+            "@walletconnect/jsonrpc-utils": "1.0.8",
+            "@walletconnect/jsonrpc-ws-connection": "1.0.12",
             "@walletconnect/keyvaluestorage": "^1.0.2",
             "@walletconnect/logger": "^2.0.1",
             "@walletconnect/relay-api": "^1.0.9",
             "@walletconnect/relay-auth": "^1.0.4",
             "@walletconnect/safe-json": "^1.0.2",
             "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.7.2",
-            "@walletconnect/utils": "2.7.2",
+            "@walletconnect/types": "2.9.0",
+            "@walletconnect/utils": "2.9.0",
             "events": "^3.3.0",
             "lodash.isequal": "4.5.0",
             "uint8arrays": "^3.1.0"
@@ -42070,33 +41608,32 @@
           }
         },
         "@walletconnect/types": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-          "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+          "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
           "requires": {
             "@walletconnect/events": "^1.0.1",
             "@walletconnect/heartbeat": "1.2.1",
-            "@walletconnect/jsonrpc-types": "^1.0.2",
+            "@walletconnect/jsonrpc-types": "1.0.3",
             "@walletconnect/keyvaluestorage": "^1.0.2",
             "@walletconnect/logger": "^2.0.1",
             "events": "^3.3.0"
           }
         },
         "@walletconnect/utils": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-          "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+          "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
           "requires": {
             "@stablelib/chacha20poly1305": "1.0.1",
             "@stablelib/hkdf": "1.0.1",
             "@stablelib/random": "^1.0.2",
             "@stablelib/sha256": "1.0.1",
             "@stablelib/x25519": "^1.0.3",
-            "@walletconnect/jsonrpc-utils": "^1.0.7",
             "@walletconnect/relay-api": "^1.0.9",
             "@walletconnect/safe-json": "^1.0.2",
             "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.7.2",
+            "@walletconnect/types": "2.9.0",
             "@walletconnect/window-getters": "^1.0.1",
             "@walletconnect/window-metadata": "^1.0.1",
             "detect-browser": "5.3.0",
@@ -42186,19 +41723,18 @@
       "dev": true
     },
     "@walletconnect/universal-provider": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.7.2.tgz",
-      "integrity": "sha512-5glu7vCmq3SFUYgniICf7CUZMwrd6FNS/qnCjrnfgW8T55Opms9YkhRpWTJFHpBdNRWF7n6z/Kss2J8olKTxKw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.9.0.tgz",
+      "integrity": "sha512-k3nkSBkF69sJJVoe17IVoPtnhp/sgaa2t+x7BvA/BKeMxE0DGdtRJdEXotTc8DBmI7o2tkq6l8+HyFBGjQ/CjQ==",
       "requires": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.7.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
-        "eip1193-provider": "1.0.1",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0"
       },
       "dependencies": {
@@ -42211,33 +41747,32 @@
           }
         },
         "@walletconnect/types": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-          "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+          "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
           "requires": {
             "@walletconnect/events": "^1.0.1",
             "@walletconnect/heartbeat": "1.2.1",
-            "@walletconnect/jsonrpc-types": "^1.0.2",
+            "@walletconnect/jsonrpc-types": "1.0.3",
             "@walletconnect/keyvaluestorage": "^1.0.2",
             "@walletconnect/logger": "^2.0.1",
             "events": "^3.3.0"
           }
         },
         "@walletconnect/utils": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-          "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+          "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
           "requires": {
             "@stablelib/chacha20poly1305": "1.0.1",
             "@stablelib/hkdf": "1.0.1",
             "@stablelib/random": "^1.0.2",
             "@stablelib/sha256": "1.0.1",
             "@stablelib/x25519": "^1.0.3",
-            "@walletconnect/jsonrpc-utils": "^1.0.7",
             "@walletconnect/relay-api": "^1.0.9",
             "@walletconnect/safe-json": "^1.0.2",
             "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.7.2",
+            "@walletconnect/types": "2.9.0",
             "@walletconnect/window-getters": "^1.0.1",
             "@walletconnect/window-metadata": "^1.0.1",
             "detect-browser": "5.3.0",
@@ -42382,154 +41917,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/parse-link-header/-/parse-link-header-3.1.0.tgz",
       "integrity": "sha512-K1undnK70vLLauqdE8bq/l98isTF2FDhcP0UPpXVSjkSWe3xhAn5eRXk5jfA1E5ycNm84Ws/rQFUD7ue11nciw=="
-    },
-    "@web3modal/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-v6Y/eQJSI2YfUTv8rGqjFabqdk3ZPjx6Fe7j5Q8fw0ZWF1YRGM3mySG457qtKQ7D7E1kNKA3BHbaOZ3pgQoG6A==",
-      "requires": {
-        "buffer": "6.0.3",
-        "valtio": "1.10.5"
-      }
-    },
-    "@web3modal/standalone": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.4.1.tgz",
-      "integrity": "sha512-ZrI5LwWeT9sd8A3FdIX/gBp3ZrzrX882Ln1vJN0LTCmeP2OUsYcW5bPxjv1PcJ1YUBY7Tg4aTgMUnAVTTuqb+w==",
-      "requires": {
-        "@web3modal/core": "2.4.1",
-        "@web3modal/ui": "2.4.1"
-      }
-    },
-    "@web3modal/ui": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.4.1.tgz",
-      "integrity": "sha512-x1ceyd3mMJsIHs5UUTLvE+6qyCjhyjL6gB/wVmTDbwASHSQIVyshQJ+s7BwIEMP/pbAsYDg+/M8EiUuE+/E/kg==",
-      "requires": {
-        "@web3modal/core": "2.4.1",
-        "lit": "2.7.4",
-        "motion": "10.15.5",
-        "qrcode": "1.5.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "qrcode": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-          "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
-          "requires": {
-            "dijkstrajs": "^1.0.1",
-            "encode-utf8": "^1.0.3",
-            "pngjs": "^5.0.0",
-            "yargs": "^15.3.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -43483,14 +42870,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
     },
     "axobject-query": {
       "version": "3.2.1",
@@ -44473,6 +43852,49 @@
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-2.6.2.tgz",
       "integrity": "sha512-0tOHJNMF9+4R3qcbBL+4IxLErpaYSYvzs10aXuECDbZdJOuJHdagJMAqvLdeaUQTI/o2uSCDRpet6ywDiKOAYw==",
       "dev": true
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "clone": {
       "version": "2.1.2",
@@ -45594,14 +45016,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
-    },
-    "eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "requires": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "ejs": {
       "version": "3.1.9",
@@ -47464,7 +46878,8 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -49227,9 +48642,9 @@
       }
     },
     "jayson": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
-      "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
+      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
       "requires": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -49241,7 +48656,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -50126,9 +49540,9 @@
       }
     },
     "lit": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.4.tgz",
-      "integrity": "sha512-cgD7xrZoYr21mbrkZIuIrj98YTMw/snJPg52deWVV4A8icLyNHI3bF70xsJeAgwTuiq5Kkd+ZR8gybSJDCPB7g==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
+      "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
       "requires": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -50146,9 +49560,9 @@
       }
     },
     "lit-html": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.4.tgz",
-      "integrity": "sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.5.tgz",
+      "integrity": "sha512-YqUzpisJodwKIlbMFCtyrp58oLloKGnnPLMJ1t23cbfIJjg/H9pvLWK4XS69YeubK5HUs1UE4ys9w5dP1zg6IA==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -50188,7 +49602,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -50957,16 +50372,16 @@
       }
     },
     "motion": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-10.15.5.tgz",
-      "integrity": "sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
       "requires": {
         "@motionone/animation": "^10.15.1",
-        "@motionone/dom": "^10.15.5",
-        "@motionone/svelte": "^10.15.5",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
-        "@motionone/vue": "^10.15.5"
+        "@motionone/vue": "^10.16.2"
       }
     },
     "move-file": {
@@ -52562,114 +51977,6 @@
         "encode-utf8": "^1.0.3",
         "pngjs": "^5.0.0",
         "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
       }
     },
     "qrcode-generator": {
@@ -55284,9 +54591,9 @@
       }
     },
     "valtio": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.5.tgz",
-      "integrity": "sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.7.tgz",
+      "integrity": "sha512-XUwXJ9twXqwfVhXlcbYlCcRUUSOmp8RcJODVAxPrUZc2jh3com13B49MOL/cbgcTOX+5yf7wdMqbFGR7ba2sPg==",
       "requires": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -55438,14 +54745,14 @@
       }
     },
     "wagmi": {
-      "version": "0.12.13",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.13.tgz",
-      "integrity": "sha512-1J+F68MztodPUo2OIFImiC3OoZD4gdryxTidfwQz9LJawXdBNmAOFvq0LQClrrqgFk0Gd3EoLo/MKGiEn2RsMg==",
+      "version": "0.12.19",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.19.tgz",
+      "integrity": "sha512-S/el9BDb/HNeQWh1v8TvntMPX/CgKLDAoJqDb8i7jifLfWPqFL7gor3vnI1Vs6ZlB8uh7m+K1Qyg+mKhbITuDQ==",
       "requires": {
         "@tanstack/query-sync-storage-persister": "^4.27.1",
         "@tanstack/react-query": "^4.28.0",
         "@tanstack/react-query-persist-client": "^4.28.0",
-        "@wagmi/core": "0.10.11",
+        "@wagmi/core": "0.10.17",
         "abitype": "^0.3.0",
         "use-sync-external-store": "^1.2.0"
       }
@@ -56185,6 +55492,73 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "yargs-parser": {
       "version": "20.2.9",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@datadog/browser-rum": "^4.38.0",
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.5",
-    "@rainbow-me/rainbowkit": "^0.12.8",
+    "@rainbow-me/rainbowkit": "^0.12.15",
     "@typescript-eslint/parser": "^5.59.9",
     "@vitejs/plugin-react": "^4.0.0",
     "@wagmi/core": "^0.10.11",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,5 +40,6 @@ interface ImportMeta {
     VITE_XMTP_ENVIRONMENT: string;
     VITE_GOOGLE_TAG_ID: string | undefined;
     VITE_UNS_TOKEN: string;
+    VITE_PROJECT_ID: string;
   };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,7 +22,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: "XMTP Inbox Web",
-  projectId: import.meta.env.VITE_PROJECT_ID ?? "",
+  projectId: import.meta.env.VITE_PROJECT_ID,
   chains,
 });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: "XMTP Inbox Web",
+  projectId: import.meta.env.VITE_PROJECT_ID ?? "",
   chains,
 });
 


### PR DESCRIPTION
Bumps version and adds required project ID field for v2 compatibility.