### PR TITLE
Fix recording icon on mount, add log

### DIFF
--- a/src/controllers/MessagePreviewCardController.tsx
+++ b/src/controllers/MessagePreviewCardController.tsx
@@ -26,6 +26,11 @@ export const MessagePreviewCardController = ({
   const recipientWalletAddress = useXmtpStore(
     (state) => state.recipientWalletAddress,
   );
+
+  const previewKeys = Array.from(previewMessages.keys());
+  // eslint-disable-next-line no-console
+  console.log("ADDRESSES", previewKeys);
+
   const setRecipientWalletAddress = useXmtpStore(
     (state) => state.setRecipientWalletAddress,
   );

--- a/src/hooks/useVoiceRecording.tsx
+++ b/src/hooks/useVoiceRecording.tsx
@@ -50,7 +50,7 @@ export const useVoiceRecording = ({
           setAttachment(newAttachment);
         });
       },
-      askPermissionOnMount: true,
+      askPermissionOnMount: false,
     });
 
   return {


### PR DESCRIPTION
This PR removes the ask permission mic on mount check which showed a recording icon when it was not yet recording. It now asks permission only upon pressing the microphone icon, which would be the expected behavior.

Also added a log per a request for this. 