### PR TITLE
Bulk UD Reverse Resolution

### DIFF
--- a/src/controllers/MessagePreviewCardController.tsx
+++ b/src/controllers/MessagePreviewCardController.tsx
@@ -41,7 +41,6 @@ export const MessagePreviewCardController = ({
   });
 
   // Get UNS name
-  // const [previewUnsName, setPreviewUnsName] = useState<string | null>();
   const previewUnsName =
     unsNames && convo?.peerAddress.toLowerCase() in unsNames
       ? unsNames[convo?.peerAddress.toLowerCase()]

--- a/src/controllers/MessagePreviewCardController.tsx
+++ b/src/controllers/MessagePreviewCardController.tsx
@@ -1,23 +1,20 @@
 import { useLastMessage, type CachedConversation } from "@xmtp/react-sdk";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useEnsAvatar, useEnsName } from "wagmi";
 import { useTranslation } from "react-i18next";
 import { MessagePreviewCard } from "../component-library/components/MessagePreviewCard/MessagePreviewCard";
-import {
-  XMTP_FEEDBACK_ADDRESS,
-  fetchUnsName,
-  isValidLongWalletAddress,
-  shortAddress,
-} from "../helpers";
+import { XMTP_FEEDBACK_ADDRESS, shortAddress } from "../helpers";
 import type { address } from "../pages/inbox";
 import { useXmtpStore } from "../store/xmtp";
 
 interface MessagePreviewCardControllerProps {
   convo: CachedConversation;
+  unsNames?: { [key: string]: string } | null;
 }
 
 export const MessagePreviewCardController = ({
   convo,
+  unsNames,
 }: MessagePreviewCardControllerProps) => {
   const { t } = useTranslation();
   const lastMessage = useLastMessage(convo.topic);
@@ -44,20 +41,11 @@ export const MessagePreviewCardController = ({
   });
 
   // Get UNS name
-  const [previewUnsName, setPreviewUnsName] = useState<string | null>();
-
-  useEffect(() => {
-    const getUns = async () => {
-      if (isValidLongWalletAddress(convo?.peerAddress || "")) {
-        const name = await fetchUnsName(convo?.peerAddress);
-        setPreviewUnsName(name);
-      } else {
-        setPreviewUnsName(null);
-      }
-    };
-
-    void getUns();
-  }, [convo?.peerAddress]);
+  // const [previewUnsName, setPreviewUnsName] = useState<string | null>();
+  const previewUnsName =
+    unsNames && convo?.peerAddress.toLowerCase() in unsNames
+      ? unsNames[convo?.peerAddress.toLowerCase()]
+      : null;
 
   // Helpers
   const isSelected = conversationTopic === convo.topic;


### PR DESCRIPTION
Updated Message previews to utilize bulk reverse resolution. 

Currently, https://xmtp.chat/inbox is throwing 429 errors (being masked by CORS) due to API rate limiting. The root cause of the rate limiting is the message preview cards. 

I have added a new API call for our bulk resolution service which can support up to 1000 wallet addresses (message previews) in a single api call. This drastically cuts down on the network activity and possibility of rate limits. 

I have also updated the base URL for the other API calls to use our new standard.