### PR TITLE
Refactor ENS/UNS lookups

### DIFF
--- a/src/controllers/ConversationListController.tsx
+++ b/src/controllers/ConversationListController.tsx
@@ -5,7 +5,7 @@ import useListConversations from "../hooks/useListConversations";
 import { ConversationList } from "../component-library/components/ConversationList/ConversationList";
 import { MessagePreviewCardController } from "./MessagePreviewCardController";
 import useStreamAllMessages from "../hooks/useStreamAllMessages";
-import { throttledUpdateConversationIdentities } from "../helpers/conversation";
+import { updateConversationIdentities } from "../helpers/conversation";
 
 type ConversationListControllerProps = {
   setStartedFirstMessage: (startedFirstMessage: boolean) => void;
@@ -21,12 +21,12 @@ export const ConversationListController = ({
 
   // when the conversations are loaded, update their identities
   useEffect(() => {
-    const updateConversationIdentities = async () => {
+    const runUpdate = async () => {
       if (isLoaded) {
-        await throttledUpdateConversationIdentities(conversations, db);
+        await updateConversationIdentities(conversations, db);
       }
     };
-    void updateConversationIdentities();
+    void runUpdate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded]);
 

--- a/src/controllers/FullConversationController.tsx
+++ b/src/controllers/FullConversationController.tsx
@@ -5,7 +5,7 @@ import { DateDivider } from "../component-library/components/DateDivider/DateDiv
 import { FullConversation } from "../component-library/components/FullConversation/FullConversation";
 import { FullMessageController } from "./FullMessageController";
 import { isMessageSupported } from "../helpers/isMessagerSupported";
-import { updatePeerAddressIdentity } from "../helpers/conversation";
+import { updateConversationIdentity } from "../helpers/conversation";
 
 type FullConversationControllerProps = {
   conversation: CachedConversation;
@@ -19,7 +19,7 @@ export const FullConversationController: React.FC<
   const { db } = useDb();
 
   useEffect(() => {
-    void updatePeerAddressIdentity(conversation, db);
+    void updateConversationIdentity(conversation, db);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversation.peerAddress]);
 

--- a/src/controllers/MessagePreviewCardController.tsx
+++ b/src/controllers/MessagePreviewCardController.tsx
@@ -1,11 +1,13 @@
 import { useLastMessage, type CachedConversation } from "@xmtp/react-sdk";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { MessagePreviewCard } from "../component-library/components/MessagePreviewCard/MessagePreviewCard";
 import { shortAddress } from "../helpers";
 import { useXmtpStore } from "../store/xmtp";
-import type { PeerIdentityMetadata } from "../helpers/conversation";
-import { getPeerAddressIdentity } from "../helpers/conversation";
+import {
+  getCachedPeerAddressAvatar,
+  getCachedPeerAddressName,
+} from "../helpers/conversation";
 
 interface MessagePreviewCardControllerProps {
   convo: CachedConversation;
@@ -34,8 +36,9 @@ export const MessagePreviewCardController = ({
     (conversation: CachedConversation) => {
       if (recipientAddress !== conversation.peerAddress) {
         const peerAddress = conversation.peerAddress as `0x${string}`;
-        const { name, avatar } = getPeerAddressIdentity(conversation);
+        const avatar = getCachedPeerAddressAvatar(conversation);
         setRecipientAvatar(avatar);
+        const name = getCachedPeerAddressName(conversation);
         setRecipientName(name);
         setRecipientAddress(peerAddress);
         setRecipientOnNetwork(true);
@@ -64,11 +67,6 @@ export const MessagePreviewCardController = ({
       : lastMessage?.content
     : undefined;
 
-  const conversationPeerIdentity = useMemo(
-    () => convo.metadata?.peerIdentity as PeerIdentityMetadata,
-    [convo.metadata?.peerIdentity],
-  );
-
   return (
     <MessagePreviewCard
       isSelected={isSelected}
@@ -76,14 +74,15 @@ export const MessagePreviewCardController = ({
       text={content}
       datetime={convo?.updatedAt}
       displayAddress={
-        conversationPeerIdentity?.name ?? shortAddress(convo?.peerAddress || "")
+        getCachedPeerAddressName(convo) ??
+        shortAddress(convo?.peerAddress || "")
       }
       onClick={() => {
         if (convo) {
           void onConvoClick?.(convo);
         }
       }}
-      avatarUrl={conversationPeerIdentity?.avatar || ""}
+      avatarUrl={getCachedPeerAddressAvatar(convo) || ""}
       conversationDomain={shortAddress(conversationDomain)}
       address={convo?.peerAddress}
     />

--- a/src/helpers/conversation.ts
+++ b/src/helpers/conversation.ts
@@ -1,7 +1,6 @@
 import {
   updateConversationMetadata,
   type CachedConversation,
-  getCachedConversationByTopic,
 } from "@xmtp/react-sdk";
 import type Dexie from "dexie";
 import type { ETHAddress } from "./string";
@@ -11,130 +10,150 @@ import {
   throttledFetchEnsName,
   throttledFetchAddressName,
 } from "./string";
-import { chunkArray, memoizeThrottle } from "./functions";
-import { API_FETCH_THROTTLE } from "./constants";
+import { chunkArray } from "./functions";
 
-export type PeerAddressIdentity = {
-  name: string | null;
-  avatar: string | null;
-};
-
-export type PeerIdentityMetadata = PeerAddressIdentity | undefined;
+export type PeerAddressAvatar = string | null;
+export type PeerAddressName = string | null;
 
 /**
- * Get the peer identity of a conversation
+ * Get the cached name of a conversation's peer address
  *
- * @param conversation The conversation to get the peer identity of
- * @returns The peer identity of the conversation
+ * @param conversation The conversation
+ * @returns The resolved name of the conversation's peer address
  */
-export const getPeerAddressIdentity = (conversation: CachedConversation) => {
-  const metadata = conversation.metadata?.peerIdentity as PeerIdentityMetadata;
-  return {
-    name: metadata?.name || null,
-    avatar: metadata?.avatar || null,
-  };
-};
+export const getCachedPeerAddressName = (conversation: CachedConversation) =>
+  conversation.metadata?.peerAddressName as PeerAddressName;
 
 /**
- * Get the peer identity of a conversation
+ * Fetch the resolved name of a conversation's peer address if it's not present
+ * in the cache
  *
- * @param conversation The conversation to get the peer identity of
- * @returns The peer identity of the conversation
+ * @param conversation The conversation
+ * @returns The resolved name of the conversation's peer address
  */
-export const fetchPeerAddressIdentity = async (
+export const fetchPeerAddressName = async (
   conversation: CachedConversation,
 ) => {
-  // first check if the peer identity is cached
-  let { name, avatar } = getPeerAddressIdentity(conversation);
+  // first check if the name is cached
+  let name = getCachedPeerAddressName(conversation);
   if (!name) {
-    name = await throttledFetchAddressName(
-      conversation.peerAddress as ETHAddress,
-    );
+    name =
+      (await throttledFetchAddressName(
+        conversation.peerAddress as ETHAddress,
+      )) ?? null;
   }
-  if (!avatar && name) {
-    avatar = await throttledFetchEnsAvatar({
-      name,
-    });
-  }
-  return {
-    name,
-    avatar,
-  };
+  return name;
 };
 
 /**
- * Set the peer identity of a conversation
+ * Set the peer address name in a conversation
  *
- * @param name The resolved name of the peer address
- * @param avatar The resolved avatar of the peer address
- * @param conversation The conversation to update
+ * @param name The name for the peer address
+ * @param conversation The conversation
  * @param db DB instance
  */
-export const setPeerAddressIdentity = async (
-  name: string | null | undefined,
-  avatar: string | null | undefined,
+export const setPeerAddressName = async (
+  name: string | null,
   conversation: CachedConversation,
   db: Dexie,
 ) => {
-  // always use the most up-to-date conversation
-  const latestConversation = await getCachedConversationByTopic(
+  // store peer address name in conversation metadata
+  await updateConversationMetadata(
     conversation.walletAddress,
     conversation.topic,
+    "peerAddressName",
+    name,
     db,
   );
-  if (latestConversation) {
-    const identity = getPeerAddressIdentity(latestConversation);
-    // store peer address identity in conversation metadata
-    await updateConversationMetadata(
-      conversation.walletAddress,
-      conversation.topic,
-      "peerIdentity",
-      // undefined is a special value that means we don't want to update the
-      // value, but rather keep the existing value
-      {
-        name: name === undefined ? identity.name : name,
-        avatar: avatar === undefined ? identity.avatar : avatar,
-      },
-      db,
-    );
-  }
 };
 
 /**
- * Update the peer identity of a conversation
+ * Get the cached avatar of a conversation's peer address
  *
- * @param conversation The conversation to update
+ * @param conversation The conversation
+ * @returns The avatar of the conversation's peer address
+ */
+export const getCachedPeerAddressAvatar = (conversation: CachedConversation) =>
+  conversation.metadata?.peerAddressAvatar as PeerAddressAvatar;
+
+/**
+ * Fetch the avatar of a conversation's peer address if it's not present
+ * in the cache
+ *
+ * @param conversation The conversation
+ * @returns The avatar of the conversation's peer address
+ */
+export const fetchPeerAddressAvatar = async (
+  conversation: CachedConversation,
+) => {
+  // first check if the avatar is cached
+  let avatar = getCachedPeerAddressAvatar(conversation);
+  if (!avatar) {
+    // check for a cached name
+    const name = getCachedPeerAddressName(conversation);
+    if (name) {
+      avatar = (await throttledFetchEnsAvatar({ name })) ?? null;
+    }
+  }
+  return avatar;
+};
+
+/**
+ * Set the peer address name in a conversation
+ *
+ * @param avatar The avatar for the peer address
+ * @param conversation The conversation
  * @param db DB instance
  */
-export const updatePeerAddressIdentity = async (
+export const setPeerAddressAvatar = async (
+  avatar: string | null,
   conversation: CachedConversation,
   db: Dexie,
 ) => {
-  const { name, avatar } = await fetchPeerAddressIdentity(conversation);
-  if (name || avatar) {
-    await setPeerAddressIdentity(name, avatar, conversation, db);
-  }
-  return {
-    name,
+  // store peer address avatar in conversation metadata
+  await updateConversationMetadata(
+    conversation.walletAddress,
+    conversation.topic,
+    "peerAddressAvatar",
     avatar,
-  };
+    db,
+  );
+};
+
+/**
+ * Given a conversation, lookup and update the identity of the conversation
+ * peer address.
+ */
+export const updateConversationIdentity = async (
+  conversation: CachedConversation,
+  db: Dexie,
+) => {
+  const name = await fetchPeerAddressName(conversation);
+  if (name) {
+    await setPeerAddressName(name, conversation, db);
+
+    const avatar = await fetchPeerAddressAvatar(conversation);
+    if (avatar) {
+      await setPeerAddressAvatar(avatar, conversation, db);
+    }
+  }
 };
 
 /**
  * Given an array of conversations, lookup and update the identities of the
  * conversation peer addresses.
  */
-const updateConversationIdentities = async (
+export const updateConversationIdentities = async (
   conversations: CachedConversation[],
   db: Dexie,
 ) => {
   // key the conversations by peer address for easy lookup
   const conversationsWithoutNameMap = conversations.reduce(
     (result, conversation) => {
-      // check if conversation already has peer identity metadata
-      const identity = getPeerAddressIdentity(conversation);
-      // skip conversations with peer identity name
-      return identity.name
+      // check if conversation already has peer address name
+      const name = getCachedPeerAddressName(conversation);
+      // skip conversations with name
+      return name
         ? result
         : {
             ...result,
@@ -146,6 +165,7 @@ const updateConversationIdentities = async (
   const addressesWithoutNames = Object.keys(
     conversationsWithoutNameMap,
   ) as ETHAddress[];
+  const resolvedAddresses: { [address: string]: string } = {};
   // make sure we have addresses to lookup
   if (addressesWithoutNames.length > 0) {
     // first check for UNS names first since we can do a bulk lookup
@@ -154,7 +174,7 @@ const updateConversationIdentities = async (
       ([address, name]) => {
         const conversation = conversationsWithoutNameMap[address];
         if (conversation) {
-          void setPeerAddressIdentity(name, null, conversation, db);
+          void setPeerAddressName(name, conversation, db);
         }
       },
     );
@@ -175,38 +195,50 @@ const updateConversationIdentities = async (
       await Promise.all(
         chunk.map(async (address) => {
           const name = await throttledFetchEnsName({ address });
-          const conversation = conversationsWithoutNameMap[address];
-          if (conversation) {
-            await setPeerAddressIdentity(name, undefined, conversation, db);
+          if (name) {
+            resolvedAddresses[address] = name;
+            const conversation = conversationsWithoutNameMap[address];
+            if (conversation) {
+              await setPeerAddressName(name, conversation, db);
+            }
           }
         }),
       );
     }
   }
-  // key the conversations by peer address for easy lookup
+  // key the conversations by ENS name for easy lookup
   const conversationsWithoutAvatarMap = conversations.reduce(
     (result, conversation) => {
+      const name =
+        // check cache
+        getCachedPeerAddressName(conversation) ??
+        // check recently resolved ENS addresses
+        resolvedAddresses[conversation.peerAddress];
+      // make sure there's a valid ENS name first
+      if (!name) {
+        return result;
+      }
       // check if conversation already has peer identity metadata
-      const identity = getPeerAddressIdentity(conversation);
-      // skip conversations with peer identity name
-      return identity.avatar
+      const avatar = getCachedPeerAddressAvatar(conversation);
+      // skip conversations with avatar
+      return avatar
         ? result
         : {
             ...result,
-            [conversation.peerAddress]: conversation,
+            [name]: conversation,
           };
     },
-    {} as { [peerAddress: string]: CachedConversation },
+    {} as { [peerName: string]: CachedConversation },
   );
-  const addressesWithoutAvatars = Object.keys(
+  const namesWithoutAvatars = Object.keys(
     conversationsWithoutAvatarMap,
   ) as ETHAddress[];
   // make sure we have addresses to lookup
-  if (addressesWithoutAvatars.length > 0) {
+  if (namesWithoutAvatars.length > 0) {
     // since there's no bulk lookup for ENS avatars, we batch the lookups in
     // groups of 10
     // eslint-disable-next-line no-restricted-syntax
-    for (const chunk of chunkArray(addressesWithoutAvatars, 10)) {
+    for (const chunk of chunkArray(namesWithoutAvatars, 10)) {
       // this will yield to the event loop to prevent UI blocking
       // eslint-disable-next-line no-await-in-loop
       await new Promise((resolve) => {
@@ -214,23 +246,14 @@ const updateConversationIdentities = async (
       });
       // eslint-disable-next-line no-await-in-loop
       await Promise.all(
-        chunk.map(async (address) => {
-          let avatar: string | null = null;
-          avatar = await throttledFetchEnsAvatar({ name: address });
-          const conversation = conversationsWithoutAvatarMap[address];
+        chunk.map(async (name) => {
+          const avatar = await throttledFetchEnsAvatar({ name });
+          const conversation = conversationsWithoutAvatarMap[name];
           if (conversation) {
-            await setPeerAddressIdentity(undefined, avatar, conversation, db);
+            await setPeerAddressAvatar(avatar, conversation, db);
           }
         }),
       );
     }
   }
 };
-
-export const throttledUpdateConversationIdentities = memoizeThrottle(
-  updateConversationIdentities,
-  API_FETCH_THROTTLE,
-  undefined,
-  (conversations: CachedConversation[]) =>
-    conversations.map((c) => c.peerAddress).join(","),
-);

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -1,10 +1,6 @@
 import { fetchEnsAvatar, fetchEnsName, fetchEnsAddress } from "@wagmi/core";
 import { getAddress } from "viem";
-import {
-  ALLOWED_ENS_SUFFIXES,
-  ALLOWED_UNS_SUFFIXES,
-  API_FETCH_THROTTLE,
-} from "./constants";
+import { ALLOWED_UNS_SUFFIXES, API_FETCH_THROTTLE } from "./constants";
 import { memoizeThrottle } from "./functions";
 
 export type ETHAddress = `0x${string}`;
@@ -37,15 +33,13 @@ export const formatTime = (d: Date | undefined): string =>
 const getMinimumNameLength = (suffixes: string[]) =>
   suffixes.reduce((result, suffix) => Math.min(result, suffix.length), 0);
 
+// ENS names can use domains TLDs
 export const isEnsName = (value: string): boolean => {
   // value must have a minimum length and contain a dot
-  if (
-    value.length < getMinimumNameLength(ALLOWED_ENS_SUFFIXES) ||
-    !value.includes(".")
-  ) {
+  if (value.length < 3 || !value.includes(".")) {
     return false;
   }
-  return ALLOWED_ENS_SUFFIXES.some((suffix) => value.endsWith(suffix));
+  return true;
 };
 
 export const isUnsName = (value: string): boolean => {

--- a/src/helpers/tests/string.test.ts
+++ b/src/helpers/tests/string.test.ts
@@ -23,12 +23,12 @@ describe("isEnsName", () => {
   it("should return true if name ends with .eth", () => {
     expect(isEnsName("test.eth")).toBe(true);
   });
-  it("should return false if name does not include eth", () => {
+  it("should return false if name does not include a period", () => {
     expect(isEnsName("01201209483434")).toBe(false);
   });
-  it("should return false if name includes but does not end with .eth", () => {
-    expect(isEnsName("test.noteth")).toBe(false);
-    expect(isEnsName("eth.test")).toBe(false);
+  it("should return false if name includes a period but is only 2 characters", () => {
+    expect(isEnsName("t.")).toBe(false);
+    expect(isEnsName(".x")).toBe(false);
   });
   it("should return false if invalid name", () => {
     expect(isEnsName("")).toBe(false);
@@ -36,27 +36,34 @@ describe("isEnsName", () => {
   it("should return true for cb.id names", () => {
     expect(isEnsName("test.cb.id")).toBe(true);
   });
+  it("should return true for any TLD", () => {
+    expect(isEnsName("test.chat")).toBe(true);
+    expect(isEnsName("test.org")).toBe(true);
+    expect(isEnsName("test.eth")).toBe(true);
+    expect(isEnsName("test.com")).toBe(true);
+    expect(isEnsName("test.net")).toBe(true);
+  });
+});
 
-  describe("shortAddress", () => {
-    it("should return properly formatted address with long addresses that start with 0x", () => {
-      const address = "0x3843594754958459849584232930739572065843";
-      expect(shortAddress(address)).toBe("0x3843...5843");
-    });
-    it("should not format long addresses that do not start with 0x", () => {
-      const address = "123843594754958459849584232930";
-      expect(shortAddress(address)).toBe(address);
-    });
-    it("should not format short addresses that start with 0x", () => {
-      const address = "0xabc";
-      expect(shortAddress(address)).toBe(address);
-    });
-    it("should not format short addresses that do not start with 0x", () => {
-      const address = "abc";
-      expect(shortAddress(address)).toBe(address);
-    });
-    it("should handle empty string inputs by returning an empty string", () => {
-      expect(shortAddress("")).toBe("");
-    });
+describe("shortAddress", () => {
+  it("should return properly formatted address with long addresses that start with 0x", () => {
+    const address = "0x3843594754958459849584232930739572065843";
+    expect(shortAddress(address)).toBe("0x3843...5843");
+  });
+  it("should not format long addresses that do not start with 0x", () => {
+    const address = "123843594754958459849584232930";
+    expect(shortAddress(address)).toBe(address);
+  });
+  it("should not format short addresses that start with 0x", () => {
+    const address = "0xabc";
+    expect(shortAddress(address)).toBe(address);
+  });
+  it("should not format short addresses that do not start with 0x", () => {
+    const address = "abc";
+    expect(shortAddress(address)).toBe(address);
+  });
+  it("should handle empty string inputs by returning an empty string", () => {
+    expect(shortAddress("")).toBe("");
   });
 });
 

--- a/src/hooks/useAddressInput.ts
+++ b/src/hooks/useAddressInput.ts
@@ -84,22 +84,21 @@ export const useAddressInput = () => {
         // input is a valid ETH address
         if (isValidLongWalletAddress(recipientInput)) {
           setRecipientAddress(recipientInput);
-          // if input is an ens name
+          // if input is a uns name
+        } else if (isUnsName(recipientInput)) {
+          setRecipientState("loading");
+          // fetch uns address
+          const address = await throttledFetchUnsAddress(recipientInput);
+          if (address) {
+            setRecipientAddress(address);
+            setRecipientName(recipientInput);
+          }
         } else if (isEnsName(recipientInput)) {
           setRecipientState("loading");
           // fetch ens address
           const address = await throttledFetchEnsAddress({
             name: recipientInput,
           });
-          if (address) {
-            setRecipientAddress(address);
-            setRecipientName(recipientInput);
-          }
-          // if input is a uns name
-        } else if (isUnsName(recipientInput)) {
-          setRecipientState("loading");
-          // fetch uns address
-          const address = await throttledFetchUnsAddress(recipientInput);
           if (address) {
             setRecipientAddress(address);
             setRecipientName(recipientInput);

--- a/src/hooks/useStreamAllMessages.tsx
+++ b/src/hooks/useStreamAllMessages.tsx
@@ -6,7 +6,7 @@ import type { DecodedMessage } from "@xmtp/react-sdk";
 import { useCallback, useRef } from "react";
 import { useAccount } from "wagmi";
 import { shortAddress, truncate } from "../helpers";
-import type { PeerIdentityMetadata } from "../helpers/conversation";
+import { getCachedPeerAddressName } from "../helpers/conversation";
 
 const useStreamAllMessages = () => {
   const { address: walletAddress } = useAccount();
@@ -25,21 +25,17 @@ const useStreamAllMessages = () => {
         const cachedConversation = await getCachedByTopic(
           message.conversation.topic,
         );
-        let name: string | null = null;
-        if (cachedConversation) {
-          const metadata = cachedConversation.metadata
-            ?.peerIdentity as PeerIdentityMetadata;
-          if (metadata) {
-            name = metadata.name;
-          }
-        }
 
-        // eslint-disable-next-line no-new
-        new Notification("XMTP", {
-          body: `${
-            name || shortAddress(message.senderAddress ?? "")
-          }\n${truncate(message.content as string, 75)}`,
-        });
+        if (cachedConversation) {
+          const name = getCachedPeerAddressName(cachedConversation);
+
+          // eslint-disable-next-line no-new
+          new Notification("XMTP", {
+            body: `${
+              name || shortAddress(message.senderAddress ?? "")
+            }\n${truncate(message.content as string, 75)}`,
+          });
+        }
 
         latestMsgId.current = message.id;
       }


### PR DESCRIPTION
In this PR:

* Separated peer address name and avatar cache
* Added support all ENS names
* Fixed initial conversation peer address lookups
