### PR TITLE
Fix for multiple convos with the same peer address

### DIFF
--- a/src/component-library/components/FullConversation/FullConversation.stories.tsx
+++ b/src/component-library/components/FullConversation/FullConversation.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { FullConversation } from "./FullConversation";
 import { FullMessage } from "../FullMessage/FullMessage";
-import { getMockMessage } from "../../../helpers/mocks";
+import { getMockMessage, getMockConversation } from "../../../helpers/mocks";
 
 export default {
   title: "FullConversation",
@@ -17,6 +17,8 @@ const Template: ComponentStory<typeof FullConversation> = (args) => (
     <FullConversation {...args} />
   </div>
 );
+
+const mockConversation = getMockConversation();
 
 const mockMessageFrom = getMockMessage(1, {
   content:
@@ -42,11 +44,13 @@ FullConversationWithMessages.args = {
   messages: Array(20).fill(
     <div>
       <FullMessage
+        conversation={mockConversation}
         message={mockMessageFrom}
         datetime={mockMessageFrom.sentAt}
         from={{ isSelf: false, displayAddress: "receiver" }}
       />
       <FullMessage
+        conversation={mockConversation}
         message={mockMessageTo}
         datetime={mockMessageTo.sentAt}
         from={{ isSelf: true, displayAddress: "sender" }}

--- a/src/component-library/components/MessageInput/MessageInput.tsx
+++ b/src/component-library/components/MessageInput/MessageInput.tsx
@@ -204,7 +204,7 @@ export const MessageInput = ({
           convo = cachedConversation;
         }
         // select existing or new conversation
-        if (convo) {
+        if (convo && conversationTopic !== convo.topic) {
           setConversationTopic(convo.topic);
         }
       }
@@ -220,6 +220,7 @@ export const MessageInput = ({
   }, [
     attachment,
     conversation,
+    conversationTopic,
     getCachedByPeerAddress,
     peerAddress,
     sendMessage,

--- a/src/controllers/MessagePreviewCardController.tsx
+++ b/src/controllers/MessagePreviewCardController.tsx
@@ -2,6 +2,7 @@ import { useLastMessage, type CachedConversation } from "@xmtp/react-sdk";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { MessagePreviewCard } from "../component-library/components/MessagePreviewCard/MessagePreviewCard";
+import type { ETHAddress } from "../helpers";
 import { shortAddress } from "../helpers";
 import { useXmtpStore } from "../store/xmtp";
 import {
@@ -35,7 +36,7 @@ export const MessagePreviewCardController = ({
   const onConvoClick = useCallback(
     (conversation: CachedConversation) => {
       if (recipientAddress !== conversation.peerAddress) {
-        const peerAddress = conversation.peerAddress as `0x${string}`;
+        const peerAddress = conversation.peerAddress as ETHAddress;
         const avatar = getCachedPeerAddressAvatar(conversation);
         setRecipientAvatar(avatar);
         const name = getCachedPeerAddressName(conversation);
@@ -44,10 +45,13 @@ export const MessagePreviewCardController = ({
         setRecipientOnNetwork(true);
         setRecipientState("valid");
         setRecipientInput(peerAddress);
+      }
+      if (conversationTopic !== conversation.topic) {
         setConversationTopic(conversation.topic);
       }
     },
     [
+      conversationTopic,
       recipientAddress,
       setConversationTopic,
       setRecipientAddress,


### PR DESCRIPTION
in this PR:

* fixed type issues in `FullConversation.stories.tsx`
* refactored UNS/ENS name and avatar lookups to account for multiple conversations with the same peer address
* updated logic for selecting conversations to account for multiple conversations with the same peer address