### PR TITLE
Feature: Add hook and code to pre-fill the peer address

### DIFF
--- a/src/hooks/useMessagePrefill.ts
+++ b/src/hooks/useMessagePrefill.ts
@@ -1,0 +1,12 @@
+import { useLocation } from 'react-router-dom';
+
+// A simple hook to pull an optional peerAddress and pre-fill ƒrom a URL
+function useMessagePrefill() {
+  const params = new URLSearchParams(useLocation().search);
+
+  const peerAddress = params.get('peerAddress');
+
+  return { peerAddress };
+}
+
+export default useMessagePrefill;

--- a/src/pages/dm.tsx
+++ b/src/pages/dm.tsx
@@ -12,8 +12,10 @@ const DmPage = () => {
       // address is present, set address input and go the inbox
       if (address) {
         setRecipientInput(address);
+        navigate(`/inbox?peerAddress=${address}`);
+      } else {
+        navigate("/inbox");
       }
-      navigate("/inbox");
     };
     void routeToInbox();
   }, [address, navigate, setRecipientInput]);

--- a/src/pages/inbox.tsx
+++ b/src/pages/inbox.tsx
@@ -134,12 +134,14 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
             </>
           ) : null}
         </div>
+
         {size[0] > TAILWIND_MD_BREAKPOINT ||
         recipientAddress ||
         startedFirstMessage ? (
           <div className="flex w-full flex-col h-screen overflow-hidden">
             {!conversations.length &&
             !loadingConversations &&
+            !recipientAddress &&
             !startedFirstMessage ? (
               <LearnMore
                 version="replace"

--- a/src/pages/inbox.tsx
+++ b/src/pages/inbox.tsx
@@ -4,7 +4,7 @@ import { useClient, useConversations } from "@xmtp/react-sdk";
 import { useDisconnect, useWalletClient } from "wagmi";
 import type { Attachment } from "@xmtp/content-type-remote-attachment";
 import { useNavigate } from "react-router-dom";
-import { useXmtpStore } from "../store/xmtp";
+import { RecipientAddress, useXmtpStore } from "../store/xmtp";
 import { TAILWIND_MD_BREAKPOINT, wipeKeys } from "../helpers";
 import { FullConversationController } from "../controllers/FullConversationController";
 import { AddressInputController } from "../controllers/AddressInputController";
@@ -16,6 +16,7 @@ import useWindowSize from "../hooks/useWindowSize";
 import { ConversationListController } from "../controllers/ConversationListController";
 import { useAttachmentChange } from "../hooks/useAttachmentChange";
 import useSelectedConversation from "../hooks/useSelectedConversation";
+import useMessagePrefill from "../hooks/useMessagePrefill";
 
 const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
   const navigate = useNavigate();
@@ -25,10 +26,18 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
   const { conversations } = useConversations();
   const selectedConversation = useSelectedConversation();
   const { data: walletClient } = useWalletClient();
+  const { peerAddress } = useMessagePrefill();
+
+  const setRecipientAddress = useXmtpStore((s) => s.setRecipientAddress);
 
   useEffect(() => {
     if (!client) {
-      navigate("/");
+      if (peerAddress) {
+        setRecipientAddress(peerAddress as RecipientAddress);
+        navigate(`/?peerAddress=${peerAddress}`);
+      } else {
+        navigate("/");
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client]);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,8 @@ import { useNavigate } from "react-router-dom";
 import { OnboardingStep } from "../component-library/components/OnboardingStep/OnboardingStep";
 import { classNames, isAppEnvDemo, wipeKeys } from "../helpers";
 import useInitXmtpClient from "../hooks/useInitXmtpClient";
-import { useXmtpStore } from "../store/xmtp";
+import useMessagePrefill from "../hooks/useMessagePrefill";
+import { RecipientAddress, useXmtpStore } from "../store/xmtp";
 
 const OnboardingPage = () => {
   const navigate = useNavigate();
@@ -17,6 +18,9 @@ const OnboardingPage = () => {
     useInitXmtpClient();
   const { reset: resetWagmi, disconnect: disconnectWagmi } = useDisconnect();
   const { disconnect: disconnectClient } = useClient();
+  const { peerAddress } = useMessagePrefill();
+
+  const setRecipientAddress = useXmtpStore((s) => s.setRecipientAddress);
 
   useEffect(() => {
     const routeToInbox = () => {
@@ -28,11 +32,18 @@ const OnboardingPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client]);
 
+  useEffect(() => {
+    if (peerAddress) {
+      setRecipientAddress(peerAddress as RecipientAddress);
+    }
+  }, []);
+
   const step = useMemo(() => {
     // special demo case that will skip onboarding
     if (isAppEnvDemo()) {
       return 0;
     }
+
     switch (status) {
       // XMTP identity not created
       case "new":


### PR DESCRIPTION
# Changes 

* Adds support for a `peerAddress` passed into `/` and `/inbox`
* Handles the redirect if `!client` in `Inbox`
* `useMessagePrefill` can easily add other params such as `message` if we want to expand this functionality in the future to pre-fill a message to the `peerAddress`
* Also handles the user who has not signed up for XMTP and comes in via a route like `https://xmpt.chat/dm/0x139d996C0B3ba66B5BDF3Cf688baa3b0DFF266c8`