### PR TITLE
Bugfix: subtext and resolved address check

### DIFF
--- a/src/component-library/components/AddressInput/AddressInput.tsx
+++ b/src/component-library/components/AddressInput/AddressInput.tsx
@@ -119,10 +119,10 @@ export const AddressInput = ({
               subtextColor,
             )}
             data-testid="message-to-subtext">
-            {resolvedAddress?.walletAddress
-              ? resolvedAddress?.walletAddress
-              : subtext
+            {subtext
               ? t(subtext)
+              : resolvedAddress?.walletAddress
+              ? resolvedAddress?.walletAddress
               : ""}
           </div>
         </div>


### PR DESCRIPTION
Fixed bug where a resolved address was superseding error subtext, therefore displaying the resolved address instead of the expected error message for users not yet connected to the network.