### PR TITLE
Set `invalid` state when name lookups fail

### DIFF
--- a/src/hooks/useAddressInput.ts
+++ b/src/hooks/useAddressInput.ts
@@ -9,6 +9,7 @@ import {
   throttledFetchEnsAvatar,
   throttledFetchEnsName,
   throttledFetchUnsAddress,
+  throttledFetchUnsName,
 } from "../helpers";
 import { useXmtpStore } from "../store/xmtp";
 
@@ -43,11 +44,17 @@ export const useAddressInput = () => {
           // no name
           if (!recipientName) {
             setRecipientState("loading");
-            // check for name
-            const name = await throttledFetchEnsName({
-              address: recipientAddress,
-            });
-            setRecipientName(name);
+            // check for UNS name
+            const unsName = await throttledFetchUnsName(recipientAddress);
+            if (unsName) {
+              setRecipientName(unsName);
+            } else {
+              // check for ENS name
+              const ensName = await throttledFetchEnsName({
+                address: recipientAddress,
+              });
+              setRecipientName(ensName);
+            }
           }
         } catch (e) {
           console.error(e);

--- a/src/hooks/useAddressInput.ts
+++ b/src/hooks/useAddressInput.ts
@@ -39,33 +39,45 @@ export const useAddressInput = () => {
     const fetchAddressIdentity = async () => {
       // must have a valid recipient address
       if (recipientAddress) {
-        // no name
-        if (!recipientName) {
-          setRecipientState("loading");
-          // check for name
-          const name = await throttledFetchEnsName({
-            address: recipientAddress,
-          });
-          setRecipientName(name);
-        }
-        // no avatar
-        if (!recipientAvatar && recipientName) {
-          setRecipientState("loading");
-          // check for avatar
-          const avatar = await throttledFetchEnsAvatar({
-            name: recipientName,
-          });
-          setRecipientAvatar(avatar);
-        }
-        // make sure we can message the recipient
-        if (!recipientOnNetwork) {
-          setRecipientState("loading");
-          const validRecipient = await canMessage(recipientAddress);
-          if (validRecipient) {
-            setRecipientOnNetwork(true);
-          } else {
-            setRecipientOnNetwork(false);
+        try {
+          // no name
+          if (!recipientName) {
+            setRecipientState("loading");
+            // check for name
+            const name = await throttledFetchEnsName({
+              address: recipientAddress,
+            });
+            setRecipientName(name);
           }
+        } catch (e) {
+          console.error(e);
+        }
+        try {
+          // no avatar
+          if (!recipientAvatar && recipientName) {
+            setRecipientState("loading");
+            // check for avatar
+            const avatar = await throttledFetchEnsAvatar({
+              name: recipientName,
+            });
+            setRecipientAvatar(avatar);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+        try {
+          // make sure we can message the recipient
+          if (!recipientOnNetwork) {
+            setRecipientState("loading");
+            const validRecipient = await canMessage(recipientAddress);
+            if (validRecipient) {
+              setRecipientOnNetwork(true);
+            } else {
+              setRecipientOnNetwork(false);
+            }
+          }
+        } catch (e) {
+          console.error(e);
         }
         setRecipientState("valid");
       }

--- a/src/hooks/useAddressInput.ts
+++ b/src/hooks/useAddressInput.ts
@@ -92,6 +92,8 @@ export const useAddressInput = () => {
           if (address) {
             setRecipientAddress(address);
             setRecipientName(recipientInput);
+          } else {
+            setRecipientState("invalid");
           }
         } else if (isEnsName(recipientInput)) {
           setRecipientState("loading");
@@ -102,6 +104,8 @@ export const useAddressInput = () => {
           if (address) {
             setRecipientAddress(address);
             setRecipientName(recipientInput);
+          } else {
+            setRecipientState("invalid");
           }
         }
       } catch {


### PR DESCRIPTION
when ENS/UNS name lookups fails, this change will set the state to `invalid`, clearing the loading state and displaying an appropriate message.