### PR TITLE
Upgrade Frames Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@xmtp/content-type-remote-attachment": "^1.1.4",
         "@xmtp/content-type-reply": "^1.1.5",
         "@xmtp/experimental-content-type-screen-effect": "^1.0.2",
-        "@xmtp/frames-client": "0.2.0",
+        "@xmtp/frames-client": "0.3.2",
         "@xmtp/react-sdk": "^5.0.1",
         "buffer": "^6.0.3",
         "date-fns": "^2.29.3",
@@ -14602,9 +14602,9 @@
       }
     },
     "node_modules/@xmtp/frames-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/frames-client/-/frames-client-0.2.0.tgz",
-      "integrity": "sha512-ezjhMd+8lvGD7RW7wd1yGqdWwpH9ngk4XooAmZMS56KvME4952OaoFatPf55ZQBq/4tZOzGjAgSlAYGWDbizqA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/frames-client/-/frames-client-0.3.2.tgz",
+      "integrity": "sha512-61rxA7YcNUUKndQ9e5X44LNVwWJCrrZR6sBGOWLckfMK00LqRasoiLgom1PlR34c17a59PPZmagxoNQ2QCto7A==",
       "dependencies": {
         "@noble/hashes": "^1.3.3",
         "@xmtp/proto": "3.41.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@xmtp/content-type-remote-attachment": "^1.1.4",
     "@xmtp/content-type-reply": "^1.1.5",
     "@xmtp/experimental-content-type-screen-effect": "^1.0.2",
-    "@xmtp/frames-client": "0.2.0",
+    "@xmtp/frames-client": "0.3.2",
     "@xmtp/react-sdk": "^5.0.1",
     "buffer": "^6.0.3",
     "date-fns": "^2.29.3",

--- a/src/component-library/components/Frame/Frame.tsx
+++ b/src/component-library/components/Frame/Frame.tsx
@@ -1,10 +1,14 @@
+import type { FrameButton } from "../../../helpers/getFrameInfo";
 import { GhostButton } from "../GhostButton/GhostButton";
 
 type FrameProps = {
   image: string;
   title: string;
-  buttons: string[];
-  handleClick: (buttonNumber: number) => Promise<void>;
+  buttons: FrameButton[];
+  handleClick: (
+    buttonNumber: number,
+    action: FrameButton["action"],
+  ) => Promise<void>;
   frameButtonUpdating: number;
 };
 
@@ -23,12 +27,12 @@ export const Frame = ({
           return null;
         }
         const handlePress = () => {
-          void handleClick(index + 1);
+          void handleClick(index + 1, button.action);
         };
         return (
           <GhostButton
-            key={button}
-            label={button}
+            key={button.text}
+            label={button.text}
             onClick={handlePress}
             isLoading={frameButtonUpdating === index + 1}
             isDisabled={frameButtonUpdating > 0}

--- a/src/controllers/FullMessageController.tsx
+++ b/src/controllers/FullMessageController.tsx
@@ -56,15 +56,13 @@ export const FullMessageController = ({
       conversationTopic: conversationTopic as string,
       participantAccountAddresses: [client.address, conversation.peerAddress],
     });
-    if (action === "post") {
+    if (action === "post" || !action) {
       const updatedFrameMetadata = await framesClient.proxy.post(
         button?.target || frameInfo.postUrl,
         payload,
       );
       const updatedFrameInfo = getFrameInfo(updatedFrameMetadata.extractedTags);
-
       setFrameInfo(updatedFrameInfo);
-      setFrameButtonUpdating(0);
     } else if (action === "post_redirect") {
       const { redirectedTo } = await framesClient.proxy.postRedirect(
         button?.target || frameInfo.postUrl,
@@ -74,6 +72,7 @@ export const FullMessageController = ({
     } else if (action === "link" && button?.target) {
       window.open(button.target, "_blank");
     }
+    setFrameButtonUpdating(0);
   };
 
   useEffect(() => {

--- a/src/controllers/FullMessageController.tsx
+++ b/src/controllers/FullMessageController.tsx
@@ -11,6 +11,7 @@ import MessageContentController from "./MessageContentController";
 import { useXmtpStore } from "../store/xmtp";
 import { Frame } from "../component-library/components/Frame/Frame";
 import { getFrameInfo } from "../helpers/getFrameInfo";
+import { readMetadata } from "../helpers/openFrames";
 
 interface FullMessageControllerProps {
   message: CachedMessageWithId;
@@ -65,7 +66,7 @@ export const FullMessageController = ({
       ],
     });
 
-    const updatedFrameMetadata = await FramesClient.postToFrame(
+    const updatedFrameMetadata = await framesClient.proxy.post(
       frameInfo.postUrl,
       payload,
     );
@@ -86,7 +87,7 @@ export const FullMessageController = ({
           const isUrl = !!word.match(urlRegex)?.[0];
 
           if (isUrl) {
-            const metadata = await FramesClient.readMetadata(word);
+            const metadata = await readMetadata(word);
             if (metadata) {
               const info = getFrameInfo(metadata.extractedTags);
               setFrameInfo(info);

--- a/src/controllers/FullMessageController.tsx
+++ b/src/controllers/FullMessageController.tsx
@@ -2,7 +2,6 @@ import type { CachedConversation, CachedMessageWithId } from "@xmtp/react-sdk";
 import { useClient } from "@xmtp/react-sdk";
 import { FramesClient } from "@xmtp/frames-client";
 import { useEffect, useState } from "react";
-import { useWalletClient } from "wagmi";
 import { FullMessage } from "../component-library/components/FullMessage/FullMessage";
 import { classNames, shortAddress } from "../helpers";
 import MessageContentController from "./MessageContentController";

--- a/src/helpers/getFrameInfo.ts
+++ b/src/helpers/getFrameInfo.ts
@@ -61,7 +61,7 @@ export function getFrameInfo(extractedTags: Record<string, string>) {
     }
   }
   return {
-    buttons,
+    buttons: buttons.filter((b) => b),
     image,
     postUrl,
     title,

--- a/src/helpers/getFrameInfo.ts
+++ b/src/helpers/getFrameInfo.ts
@@ -1,21 +1,56 @@
+import { getButtonIndex, mediaUrl } from "./openFrames";
+
 const BUTTON_PREFIX = "fc:frame:button:";
 const IMAGE_PREFIX = "fc:frame:image";
 const POST_URL_PREFIX = "fc:frame:post_url";
 const TITLE_PREFIX = "og:title";
 
+const ALLOWED_ACTIONS = ["post", "post_redirect", "link", "mint"] as const;
+
+export type FrameButton = {
+  text?: string;
+  action?: (typeof ALLOWED_ACTIONS)[number];
+  target?: string;
+};
+
+function addButtonTag(
+  existingButtons: FrameButton[],
+  key: string,
+  value: string,
+): FrameButton[] {
+  const buttons = existingButtons;
+  const buttonIndex = getButtonIndex(key);
+  if (buttonIndex) {
+    buttons[buttonIndex] = buttons[buttonIndex] || {};
+    if (
+      key.endsWith(":action") &&
+      ALLOWED_ACTIONS.includes(value as (typeof ALLOWED_ACTIONS)[number])
+    ) {
+      buttons[buttonIndex].action = value as (typeof ALLOWED_ACTIONS)[number];
+    } else if (key.endsWith(":target")) {
+      buttons[buttonIndex].target = value;
+    } else if (key.endsWith(buttonIndex.toString())) {
+      buttons[buttonIndex].text = value;
+    }
+  }
+  return buttons;
+}
+
 export function getFrameInfo(extractedTags: Record<string, string>) {
-  const buttons: string[] = [];
+  let buttons: FrameButton[] = [];
   let image = "";
   let postUrl = "";
   let title = "";
   for (const key in extractedTags) {
     if (key) {
       if (key.startsWith(BUTTON_PREFIX)) {
-        const buttonIndex = parseInt(key.replace(BUTTON_PREFIX, ""), 10);
-        buttons[buttonIndex] = extractedTags[key];
+        buttons = addButtonTag(buttons, key, extractedTags[key]);
       }
       if (key.startsWith(IMAGE_PREFIX)) {
-        image = extractedTags[key];
+        const imageUrl = extractedTags[key];
+        image = imageUrl.startsWith("data:")
+          ? extractedTags[key]
+          : mediaUrl(imageUrl);
       }
       if (key.startsWith(POST_URL_PREFIX)) {
         postUrl = extractedTags[key];

--- a/src/helpers/openFrames.ts
+++ b/src/helpers/openFrames.ts
@@ -1,0 +1,6 @@
+import { OpenFramesProxy, type FramesApiResponse } from "@xmtp/frames-client";
+
+const proxy = new OpenFramesProxy();
+
+export const readMetadata = async (url: string): Promise<FramesApiResponse> =>
+  proxy.readMetadata(url);

--- a/src/helpers/openFrames.ts
+++ b/src/helpers/openFrames.ts
@@ -1,6 +1,17 @@
 import { OpenFramesProxy, type FramesApiResponse } from "@xmtp/frames-client";
 
 const proxy = new OpenFramesProxy();
+const BUTTON_INDEX_REGEX = /fc:frame:button:(\d)(?:$|:).*/;
 
 export const readMetadata = async (url: string): Promise<FramesApiResponse> =>
   proxy.readMetadata(url);
+
+export const mediaUrl = (url: string): string => proxy.mediaUrl(url);
+
+export const getButtonIndex = (property: string): number | undefined => {
+  const matches = property.match(BUTTON_INDEX_REGEX);
+  if (matches?.length === 2) {
+    return parseInt(matches[1], 10);
+  }
+  return undefined;
+};


### PR DESCRIPTION
## Summary

- Uses latest `@xmtp/frames-client`
- Adds support for proxying images
- Adds support for `post_redirect` action types
- Adds support for `link` action types
- Fix bug where new clients were being created when Frames buttons are clicked, causing signatures